### PR TITLE
WIP: Send code to REPL

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
         "Snippets"
     ],
     "activationEvents": [
-        "onCommand:language-julia.openPackageDirectory"
+        "onCommand:language-julia.openPackageDirectory",
+        "onCommand:language-julia.executeJuliaCodeInREPL"
     ],
     "main": "./out/src/extension",
     "contributes": {
@@ -60,8 +61,17 @@
             {
                 "command": "language-julia.openPackageDirectory",
                 "title": "julia: Open Package Directory in New Window"
+            },
+            {
+                "command": "language-julia.executeJuliaCodeInREPL",
+                "title": "julia: Execute Code"
             }
-        ]
+        ],
+        "keybindings": [{
+            "command": "language-julia.executeJuliaCodeInREPL",
+            "key": "ctrl+Enter",
+            "when": "editorTextFocus"
+        }] 
     },
     "scripts": {
         "vscode:prepublish": "node ./node_modules/vscode/bin/compile",

--- a/scripts/server.jl
+++ b/scripts/server.jl
@@ -1,0 +1,34 @@
+module _vscodeserver
+import JSON
+
+@async begin
+    server = listen("\\\\.\\pipe\\vscode-language-julia-server")
+    while true
+        sock = accept(server)
+        @async while isopen(sock)
+            msg = ""
+            process_message = false
+            try
+                msg = JSON.parse(sock)
+                process_message = true
+            catch e
+                if isa(e, EOFError)
+                else
+                    rethrow()
+                end
+            end
+
+            if process_message
+                if msg["command"] == "run"
+                    command_string = msg["body"]
+                    command_eval = parse(command_string)
+                    eval(Main, command_eval)
+                else
+                    error("Unknown command")
+                end                               
+            end
+        end
+    end
+end
+
+end


### PR DESCRIPTION
This is very experimental. You need to start one instance of julia with the following command:

```
julia -L server.jl
```

where server.jl is in the folder `scripts`.

You can then send selected text or the current line in the editor to that julia process via Ctrl+Enter.

You can start that julia REPL inside a VS code terminal window, and at that point you will have a rough integrated julia REPL and can send code from the editor to it.

This requires ~~Microsoft/vscode#8078~~ Microsoft/vscode#547 for a really smooth implementation.

Things that need to be fixed:
- [ ] automatically start julia process inside a VS code REPL. Blocked by ~~Microsoft/vscode#8078~~ Microsoft/vscode#547.
- [ ] reuse connection to julia server. I think right now I'm opening up a new connection for every command I send to the julia instance
- [ ] make cross-platform, right now only tested on Windows. Probably just need to make sure the name for named pipe works cross-platform
- [ ] error handling. There are many cases: julia instance closes, connection drops, and all sorts of other things
- [ ] come up with a plan for a testing story
