### PR TITLE
WIP: Linter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.vsix
 out
 node_modules
+scripts/lintserver/julia_pkgdir/

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,3 +8,4 @@ test/**
 src/**
 **/*.map
 tsconfig.json
+scripts/lintserver/julia_pkgdir/**

--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
     "icon": "images/julia-logo.svg",
     "categories": [
         "Languages",
-        "Snippets"
+        "Snippets",
+        "Linters"
     ],
     "activationEvents": [
-        "onCommand:language-julia.openPackageDirectory"
+        "onCommand:language-julia.openPackageDirectory",
+        "onLanguage:julia"
     ],
     "main": "./out/src/extension",
     "contributes": {
@@ -61,12 +63,37 @@
                 "command": "language-julia.openPackageDirectory",
                 "title": "julia: Open Package Directory in New Window"
             }
-        ]
+        ],
+        "configuration": {
+            "type": "object",
+            "title": "julia configuration",
+            "properties": {
+                "julia.validate.executablePath": {
+                    "type": ["string", "null"],
+                    "default": null,
+                    "description": "Points to the julia executable."
+                },
+                "julia.validate.enable": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether julia validation is enabled or not."
+                },
+                "julia.validate.run": {
+                    "type": "string",
+					"enum": ["onSave", "onType"],
+					"default": "onType",
+					"description": "Whether the linter is run on save or on type."
+                }
+            }
+        }
     },
     "scripts": {
         "vscode:prepublish": "node ./node_modules/vscode/bin/compile",
         "compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install"
+    },
+    "dependencies": {
+        "carrier": "0.3.0"
     },
     "devDependencies": {
         "typescript": "^1.8.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "language-julia",
     "displayName": "julia",
     "description": "julia language support",
-    "version": "0.3.1",
+    "version": "0.4.0-beta.1",
     "publisher": "julialang",
     "engines": {
         "vscode": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "language-julia",
     "displayName": "julia",
     "description": "julia language support",
-    "version": "0.4.0-beta.1",
+    "version": "0.4.0",
     "publisher": "julialang",
     "engines": {
         "vscode": "^1.0.0"

--- a/scripts/lintserver/lintserver.jl
+++ b/scripts/lintserver/lintserver.jl
@@ -1,0 +1,21 @@
+if VERSION < v"0.4" || VERSION >= v"0.5-"
+    println("VS Code linter only works with julia 0.4")
+else
+    try
+        eval(parse("using Lint"))
+    catch e
+        println("Installing Lint package")
+        Pkg.init()
+        Pkg.add("Compat", v"0.8.4")
+        Pkg.add("Lint", v"0.2.3")
+        eval(parse("using Lint"))
+    end
+
+    if length(Base.ARGS)!=2
+        error()
+    end
+
+    push!(LOAD_PATH, Base.ARGS[2])
+
+    lintserver(Base.ARGS[1])
+end

--- a/scripts/lintserver/lintserver.jl
+++ b/scripts/lintserver/lintserver.jl
@@ -1,14 +1,30 @@
 if VERSION < v"0.4" || VERSION >= v"0.5-"
     println("VS Code linter only works with julia 0.4")
 else
-    try
-        eval(parse("using Lint"))
-    catch e
-        println("Installing Lint package")
-        Pkg.init()
-        Pkg.add("Compat", v"0.8.4")
-        Pkg.add("Lint", v"0.2.3")
-        eval(parse("using Lint"))
+    lock_aquired = false
+    while !lock_aquired
+        try
+            @windows_only global_lock_socket_name = "\\\\.\\pipe\\vscode-language-lint-server-global-lock"
+            @unix_only global_lock_socket_name = joinpath(tempdir(), "vscode-language-lint-server-global-lock")
+            socket = listen(global_lock_socket_name)
+            try
+                try
+                    eval(parse("using Lint"))
+                catch e
+                    println("Installing Lint package")
+                    Pkg.init()
+                    Pkg.add("Compat", v"0.8.4")
+                    Pkg.add("Lint", v"0.2.3")
+                    eval(parse("using Lint"))
+                end
+            finally
+                close(socket)
+                lock_aquired = true
+            end
+        catch e
+            info("Another julia lint process is currently updating packages, trying again in 1 second.")
+            sleep(1.)
+        end
     end
 
     if length(Base.ARGS)!=2

--- a/src/async.ts
+++ b/src/async.ts
@@ -1,0 +1,187 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare function setTimeout(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timer;
+
+export interface ITask<T> {
+	(): T;
+}
+
+/**
+ * A helper to prevent accumulation of sequential async tasks.
+ *
+ * Imagine a mail man with the sole task of delivering letters. As soon as
+ * a letter submitted for delivery, he drives to the destination, delivers it
+ * and returns to his base. Imagine that during the trip, N more letters were submitted.
+ * When the mail man returns, he picks those N letters and delivers them all in a
+ * single trip. Even though N+1 submissions occurred, only 2 deliveries were made.
+ *
+ * The throttler implements this via the queue() method, by providing it a task
+ * factory. Following the example:
+ *
+ * 		var throttler = new Throttler();
+ * 		var letters = [];
+ *
+ * 		function letterReceived(l) {
+ * 			letters.push(l);
+ * 			throttler.queue(() => { return makeTheTrip(); });
+ * 		}
+ */
+export class Throttler<T> {
+
+	private activePromise: Promise<T>;
+	private queuedPromise: Promise<T>;
+	private queuedPromiseFactory: ITask<Promise<T>>;
+
+	constructor() {
+		this.activePromise = null;
+		this.queuedPromise = null;
+		this.queuedPromiseFactory = null;
+	}
+
+	public queue(promiseFactory: ITask<Promise<T>>): Promise<T> {
+		if (this.activePromise) {
+			this.queuedPromiseFactory = promiseFactory;
+
+			if (!this.queuedPromise) {
+				var onComplete = () => {
+					this.queuedPromise = null;
+
+					var result = this.queue(this.queuedPromiseFactory);
+					this.queuedPromiseFactory = null;
+
+					return result;
+				};
+
+				this.queuedPromise = new Promise<T>((resolve, reject) => {
+					this.activePromise.then(onComplete, onComplete).then(resolve);
+				});
+			}
+
+			return new Promise<T>((resolve, reject) => {
+				this.queuedPromise.then(resolve, reject);
+			});
+		}
+
+		this.activePromise = promiseFactory();
+
+		return new Promise<T>((resolve, reject) => {
+			this.activePromise.then((result: T) => {
+				this.activePromise = null;
+				resolve(result);
+			}, (err: any) => {
+				this.activePromise = null;
+				reject(err);
+			});
+		});
+	}
+}
+
+/**
+ * A helper to delay execution of a task that is being requested often.
+ *
+ * Following the throttler, now imagine the mail man wants to optimize the number of
+ * trips proactively. The trip itself can be long, so the he decides not to make the trip
+ * as soon as a letter is submitted. Instead he waits a while, in case more
+ * letters are submitted. After said waiting period, if no letters were submitted, he
+ * decides to make the trip. Imagine that N more letters were submitted after the first
+ * one, all within a short period of time between each other. Even though N+1
+ * submissions occurred, only 1 delivery was made.
+ *
+ * The delayer offers this behavior via the trigger() method, into which both the task
+ * to be executed and the waiting period (delay) must be passed in as arguments. Following
+ * the example:
+ *
+ * 		var delayer = new Delayer(WAITING_PERIOD);
+ * 		var letters = [];
+ *
+ * 		function letterReceived(l) {
+ * 			letters.push(l);
+ * 			delayer.trigger(() => { return makeTheTrip(); });
+ * 		}
+ */
+export class Delayer<T> {
+
+	public defaultDelay: number;
+	private timeout: NodeJS.Timer;
+	private completionPromise: Promise<T>;
+	private onResolve: (value: T | Thenable<T>) => void;
+	private task: ITask<T>;
+
+	constructor(defaultDelay: number) {
+		this.defaultDelay = defaultDelay;
+		this.timeout = null;
+		this.completionPromise = null;
+		this.onResolve = null;
+		this.task = null;
+	}
+
+	public trigger(task: ITask<T>, delay: number = this.defaultDelay): Promise<T> {
+		this.task = task;
+		this.cancelTimeout();
+
+		if (!this.completionPromise) {
+			this.completionPromise = new Promise<T>((resolve, reject) => {
+				this.onResolve = resolve;
+			}).then(() => {
+				this.completionPromise = null;
+				this.onResolve = null;
+
+				var result = this.task();
+				this.task = null;
+
+				return result;
+			});
+		}
+
+		this.timeout = setTimeout(() => {
+			this.timeout = null;
+			this.onResolve(null);
+		}, delay);
+
+		return this.completionPromise;
+	}
+
+	public isTriggered(): boolean {
+		return this.timeout !== null;
+	}
+
+	public cancel(): void {
+		this.cancelTimeout();
+
+		if (this.completionPromise) {
+			this.completionPromise = null;
+		}
+	}
+
+	private cancelTimeout(): void {
+		if (this.timeout !== null) {
+			clearTimeout(this.timeout);
+			this.timeout = null;
+		}
+	}
+}
+
+/**
+ * A helper to delay execution of a task that is being requested often, while
+ * preventing accumulation of consecutive executions, while the task runs.
+ *
+ * Simply combine the two mail man strategies from the Throttler and Delayer
+ * helpers, for an analogy.
+ */
+export class ThrottledDelayer<T> extends Delayer<Promise<T>> {
+
+	private throttler: Throttler<T>;
+
+	constructor(defaultDelay: number) {
+		super(defaultDelay);
+
+		this.throttler = new Throttler();
+	}
+
+	public trigger(promiseFactory: ITask<Promise<T>>, delay?: number): Promise<Promise<T>> {
+		return super.trigger(() => this.throttler.queue(promiseFactory), delay);
+	}
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,8 +4,8 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs'
 import * as path from 'path'
-
-let diagnosticCollection: vscode.DiagnosticCollection;
+import * as net from 'net';
+import JuliaValidationProvider from './linter';
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -21,6 +21,9 @@ export function activate(context: vscode.ExtensionContext) {
     let disposable = vscode.commands.registerCommand('language-julia.openPackageDirectory', openPackageDirectoryCommand);
 
     context.subscriptions.push(disposable);
+
+    let validator = new JuliaValidationProvider();
+	validator.activate(context);
 }
 
 // this method is called when your extension is deactivated

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -1,0 +1,240 @@
+'use strict';
+import * as vscode from 'vscode';
+import * as fs from 'fs'
+import * as path from 'path'
+import * as net from 'net';
+import * as readline from 'readline';
+import cp = require('child_process');
+import { ThrottledDelayer } from './async';
+import * as os from 'os';
+var carrier = require('carrier');
+
+enum RunTrigger {
+    onSave,
+    onType
+}
+
+namespace RunTrigger {
+    export let strings = {
+        onSave: 'onSave',
+        onType: 'onType'
+    };
+    export let from = function (value: string): RunTrigger {
+        if (value === 'onType') {
+            return RunTrigger.onType;
+        } else {
+            return RunTrigger.onSave;
+        }
+    };
+}
+
+function generatePipeName(pid: string) {
+    if (process.platform === 'win32') {
+        return '\\\\.\\pipe\\vscode-language-julia-lint-server-socket-' + pid;
+    }
+    else {
+        return path.join(os.tmpdir(), 'vscode-language-julia-lint-server-socket-' + pid);
+    }
+}
+
+export default class JuliaValidationProvider {
+    private validationEnabled: boolean;
+    private executable: string;
+    private trigger: RunTrigger;
+
+    private documentListener: vscode.Disposable;
+    private diagnosticCollection: vscode.DiagnosticCollection;
+    private delayers: { [key: string]: ThrottledDelayer<void> };
+
+    private juliaLinterProcess: cp.ChildProcess;
+    private extensionPath: string;
+
+    constructor() {
+        this.executable = null;
+        this.validationEnabled = true;
+        this.trigger = RunTrigger.onType;
+        this.juliaLinterProcess = null;
+        this.extensionPath = null;
+    }
+
+    public activate(context: vscode.ExtensionContext) {
+        var subscriptions = context.subscriptions;
+        this.extensionPath = context.extensionPath;
+        this.diagnosticCollection = vscode.languages.createDiagnosticCollection('julia');
+        subscriptions.push(this);
+        vscode.workspace.onDidChangeConfiguration(this.loadConfiguration, this, subscriptions);
+        this.loadConfiguration();
+
+        vscode.workspace.onDidOpenTextDocument(this.triggerValidate, this, subscriptions);
+        vscode.workspace.onDidCloseTextDocument((textDocument) => {
+            this.diagnosticCollection.delete(textDocument.uri);
+            delete this.delayers[textDocument.uri.toString()];
+        }, null, subscriptions);
+    }
+
+    public dispose(): void {
+        this.diagnosticCollection.clear();
+        this.diagnosticCollection.dispose();
+    }
+
+    private findAndStartJulia() {
+        if (this.executable !== null) {
+            this.startLintProcess(this.executable);
+        }
+        else {
+            this.startLintProcess('julia');
+        }
+    }
+
+    private startLintProcess(juliaExecPath: string) {
+        let spawnOptions = {
+            cwd: path.join(this.extensionPath, 'scripts', 'lintserver'),
+            env: {
+                JULIA_PKGDIR: path.join(this.extensionPath, 'scripts', 'lintserver', 'julia_pkgdir'),
+                HOME: process.env.HOME ? process.env.HOME : os.homedir() }
+        };
+        var originalJuliaPkgDir = process.env.JULIA_PKGDIR ? process.env.JULIA_PKGDIR : path.join(os.homedir(), '.julia', 'v0.4');
+        
+        this.juliaLinterProcess = cp.spawn(juliaExecPath, ['lintserver.jl', generatePipeName(process.pid.toString()), originalJuliaPkgDir], spawnOptions);
+
+        this.juliaLinterProcess.on('exit', () => {
+            this.juliaLinterProcess = null;
+        });
+
+        this.juliaLinterProcess.on('error', err => {
+            this.juliaLinterProcess = null;
+            vscode.window.showErrorMessage('Could not start julia.exe for linter process.');
+        });
+
+        let jlp_out_lr = readline.createInterface(this.juliaLinterProcess.stdout, this.juliaLinterProcess.stdin);
+        jlp_out_lr.on('line', data => {
+            console.log('jl linter: server output: ' + data);
+            if (data == 'Server running on port ' + generatePipeName(process.pid.toString()) + ' ...') {
+                // Configuration has changed. Reevaluate all documents.
+                vscode.workspace.textDocuments.forEach(this.triggerValidate, this);
+            }
+            else if (data == 'VS Code linter only works with julia 0.4') {
+                vscode.window.showErrorMessage('julia linter only works with julia 0.4.');
+            }
+        });
+
+        let jlp_err_lr = readline.createInterface(this.juliaLinterProcess.stderr, this.juliaLinterProcess.stdin);
+        jlp_err_lr.on('line', function (data) {
+            console.log('jl linter: server output: ' + data);
+        });
+    }
+
+    private loadConfiguration(): void {
+        let section = vscode.workspace.getConfiguration('julia');
+
+        if (section) {
+            this.validationEnabled = section.get<boolean>('validate.enable', true);
+            this.executable = section.get<string>('validate.executablePath', null);
+            this.trigger = RunTrigger.from(section.get<string>('validate.run', RunTrigger.strings.onType));
+        }
+
+        this.delayers = Object.create(null);
+        if (this.documentListener) {
+            this.documentListener.dispose();
+        }
+        this.diagnosticCollection.clear();
+
+        if (this.validationEnabled) {
+            if (this.trigger === RunTrigger.onType) {
+                this.documentListener = vscode.workspace.onDidChangeTextDocument((e) => {
+                    this.triggerValidate(e.document);
+                });
+            } else {
+                this.documentListener = vscode.workspace.onDidSaveTextDocument(this.triggerValidate, this);
+            }
+        }
+
+        if (this.juliaLinterProcess !== null) {
+            this.juliaLinterProcess.on('exit', () => {
+                this.juliaLinterProcess = null;
+                if (this.validationEnabled) {
+                    this.findAndStartJulia();
+                }
+            });
+            this.juliaLinterProcess.kill();
+        }
+        else {
+            if (this.validationEnabled) {
+                this.findAndStartJulia();
+            }
+        }
+    }
+
+    private triggerValidate(textDocument: vscode.TextDocument): void {
+        if (textDocument.languageId !== 'julia' || this.juliaLinterProcess === null || !this.validationEnabled) {
+            return;
+        }
+        let key = textDocument.uri.toString();
+        let delayer = this.delayers[key];
+        if (!delayer) {
+            delayer = new ThrottledDelayer<void>(this.trigger === RunTrigger.onType ? 250 : 0);
+            this.delayers[key] = delayer;
+        }
+        delayer.trigger(() => this.doValidate(textDocument));
+    }
+
+    private mapSeverityToVSCodeSeverity(sev: string): vscode.DiagnosticSeverity {
+        switch (sev.substring(0, 1)) {
+            case "E": return vscode.DiagnosticSeverity.Error;
+            case "W": return vscode.DiagnosticSeverity.Warning;
+            case "I": return vscode.DiagnosticSeverity.Information;
+            default: return vscode.DiagnosticSeverity.Error;
+        }
+    }
+
+    private doValidate(textDocument: vscode.TextDocument): Promise<void> {
+        var filename = textDocument.fileName;
+
+        return new Promise<void>((resolve, reject) => {
+            let diagnostics: vscode.Diagnostic[] = [];
+            let processLine = (line: string) => {
+                var colon_sep = line.indexOf(':', filename.length);
+                var space1_sep = line.indexOf(' ', colon_sep + 1);
+                var linenumber_str = line.substring(colon_sep + 1, space1_sep);
+                var linenumber = parseInt(linenumber_str) - 1;
+                var space2_sep = line.indexOf(' ', space1_sep + 1);
+                var errornumber = line.substring(space1_sep + 1, space2_sep);
+                var errormsg = line.substring(space2_sep + 1);
+
+                let range = new vscode.Range(linenumber, 0, linenumber, Number.MAX_VALUE);
+                let diagnostic = new vscode.Diagnostic(range, errormsg, this.mapSeverityToVSCodeSeverity(errornumber));
+                diagnostics.push(diagnostic);
+            };
+
+            try {
+                var client = net.connect(generatePipeName(process.pid.toString()), () => {
+                    console.log('jl linter: connected to lint server');
+                    var msg1 = filename + '\n';
+                    var msg3 = textDocument.getText();
+                    var msg2 = msg3.length.toString() + '\n';
+                    client.write(msg1 + msg2 + msg3);
+                });
+
+                client.on('error', err => {
+                    console.log('jl linter: could not connect to lint server');
+                    resolve();
+                });
+
+                carrier.carry(client, msg => {
+                    var lines = msg.split(/\r?\n/);
+
+                    lines.forEach(processLine);
+
+                    this.diagnosticCollection.set(textDocument.uri, diagnostics);
+
+                    console.log('jl linter: finished linting.');
+
+                    resolve();
+                }, 'utf8', /\r?\n\r?\n/);
+            }
+            catch (error) {
+                console.log('jl linter: unknown error.');
+            }
+        });
+    }
+}

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -103,7 +103,7 @@ export default class JuliaValidationProvider {
 
         this.juliaLinterProcess.on('error', err => {
             this.juliaLinterProcess = null;
-            vscode.window.showErrorMessage('Could not start julia.exe for linter process.');
+            vscode.window.showErrorMessage('Could not start julia for linter process.');
         });
 
         let jlp_out_lr = readline.createInterface(this.juliaLinterProcess.stdout, this.juliaLinterProcess.stdin);

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -95,7 +95,7 @@ export default class JuliaValidationProvider {
         };
         var originalJuliaPkgDir = process.env.JULIA_PKGDIR ? process.env.JULIA_PKGDIR : path.join(os.homedir(), '.julia', 'v0.4');
         
-        this.juliaLinterProcess = cp.spawn(juliaExecPath, ['lintserver.jl', generatePipeName(process.pid.toString()), originalJuliaPkgDir], spawnOptions);
+        this.juliaLinterProcess = cp.spawn(juliaExecPath, ['--startup-file=no', '--history-file=no', 'lintserver.jl', generatePipeName(process.pid.toString()), originalJuliaPkgDir], spawnOptions);
 
         this.juliaLinterProcess.on('exit', () => {
             this.juliaLinterProcess = null;


### PR DESCRIPTION
This uses Lint.jl to provide linting.

Things still to fix:
- [x] Manage linter process from extension
- [x] Operate the linter process from a private package folder that has just Lint.jl and dependencies
- [x] Properly trigger when a julia doc is shown
- [x] Move code out of main extension file
- [x] Add error handling etc.
- [x] Include process id in pipe name
- [x] Figure out whether the current way of reading the response from the socket is a good way
- [x] Figure out what happens if there are many change requests, do old ones get canceled somehow?
- [x] Make response parsing more robust (see also tonyhffong/Lint.jl#131)
- [x] Make path to julia.exe a configuration
- [x] Restart lintserver process when path to julia.exe is updated
- [x] Figure out what will happen to the private julia package dir when the extension is a) updated and b) uninstalled (Microsoft/vscode#8736)
- [x] Figure out how to use a ``using`` in a ``try`` block in julia
- [x] Fix the version of Linter.jl and other packages that are used
- [x] Come up with plan for updates of julia packages
- [x] Cross-platform support (might only work on Windows right now)
- [x] Option to disable linter
- [x] Find julia in common places if not configured
- [x] Test julia 0.5 compatability
- [x] Handle race condition at package install time
- [x] Is there a race condition with precompile?