### PR TITLE
Completion evaluation

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
             "properties": {
                 "julia.validate.executablePath": {
                     "type": ["string", "null"],
-                    "default": "/home/nova/Softwares/julia-0.5/bin/julia",
+                    "default": "null",
                     "description": "Points to the julia executable."
                 },
                 "julia.validate.enable": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,10 @@
             {
                 "command": "language-julia.openPackageDirectory",
                 "title": "julia: Open Package Directory in New Window"
+            },
+            {
+                "command": "language-julia.executeCode",
+                "title": "julia: Execute Code"
             }
         ],
         "configuration": {
@@ -70,7 +74,7 @@
             "properties": {
                 "julia.validate.executablePath": {
                     "type": ["string", "null"],
-                    "default": null,
+                    "default": "/home/nova/Softwares/julia-0.5/bin/julia",
                     "description": "Points to the julia executable."
                 },
                 "julia.validate.enable": {

--- a/scripts/completion.jl
+++ b/scripts/completion.jl
@@ -1,0 +1,70 @@
+import JSON
+using CodeTools
+
+function getCompletionResults(line::String, pos::Int)
+    names = Base.REPLCompletions.completions(line, pos)[1]
+    return map(name -> CodeTools.withmeta(name, current_module()), names)
+end
+
+function evaluateCodeBlock(code::String)
+    linecharc = cumsum(map(x->endof(x)+1, split(code, "\n")))
+    pos = start(code)
+    numlines = length(linecharc)
+    while !done(code, pos)
+        problem = false
+        ex = nothing
+        linerange = searchsorted(linecharc, pos)
+        if linerange.start > numlines
+            break
+        else
+            linebreakloc = linecharc[linerange.start]
+        end
+        if linebreakloc == pos || isempty(strip(code[pos:(linebreakloc-1)]))
+            pos = linebreakloc + 1
+            continue
+        end
+        ex = parse("")
+        try
+            (ex, pos) = parse(code, pos)
+        catch y
+            problem = true
+        end
+        if !problem
+            eval(ex)
+        else
+            break
+        end
+    end
+end
+
+while true
+    request = nothing
+    process_message = false
+    try
+        text = readline()
+        request = JSON.parse(text)
+        process_message = true
+    catch
+        if isa(e, EOFError)
+        else
+            rethrow()
+        end
+    end
+
+    if process_message
+        if request["requestType"] == "completion"
+            try
+                id = request["id"]
+                line = request["source"]
+                pos = request["columnIndex"]
+                rdata = getCompletionResults(line, pos)
+                answer = Dict("id" => id, "results" => rdata)
+                println(STDOUT, JSON.json(answer))
+            end
+        elseif request["requestType"] == "evaluation"
+            try
+                evaluateCodeBlock(request["source"])
+            end
+        end
+    end
+end

--- a/src/completionprovider.ts
+++ b/src/completionprovider.ts
@@ -1,0 +1,296 @@
+'use strict';
+
+import * as vscode from 'vscode';
+import * as net from 'net';
+import * as path from 'path';
+import * as cp from 'child_process';
+
+var cmdId: number = 0;
+var commands = new Map<number, ICommand>();
+var commandQueue: number[] = [];
+var proc: cp.ChildProcess;
+var juliaPath = 'julia';
+var juliaProcessCWD = '';
+var previousData = '';
+var client: net.Socket;
+
+export class JuliaCompletionItemProvider implements vscode.CompletionItemProvider {
+
+    public constructor(context: vscode.ExtensionContext) {
+        killProcess();
+        initialize(context.asAbsolutePath("."));
+    }
+
+    public provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Thenable<vscode.CompletionItem[]> {
+        return new Promise<vscode.CompletionItem[]>((resolve, reject) => {
+            if (!proc) {
+                return reject("Julia proc is not initialized");
+            }
+
+            let filename = document.fileName;
+            let line = document.lineAt(position.line).text;
+
+            if (line.match(/^\s*\/\//)) {
+                return resolve([]);
+            }
+
+            let wordAtposition = document.getWordRangeAtPosition(position);
+            let currentWord = "";
+            if (wordAtposition && wordAtposition.start.character < position.character) {
+                let word = document.getText(wordAtposition);
+                currentWord = word.substr(0, position.character - wordAtposition.start.character);
+            }
+
+            if (currentWord.match(/^\d+$/)) {
+                return resolve([]);
+            }
+            let request: IRequest = {
+                id: getNextCommandId(),
+                requestType: "completion",
+                source: line,
+                fileName: filename,
+                lineIndex: position.line,
+                columnIndex: position.character
+            };
+            let cmd: ICommand = {
+                id: request.id,
+                commandType: request.requestType,
+                resolve: resolve,
+                reject: reject,
+                token: token
+            };
+            try {
+                proc.stdin.write(JSON.stringify(request) + "\n");
+                commands.set(cmd.id, cmd);
+                commandQueue.push(cmd.id);
+            }
+            catch (ex) {
+                if (ex.message === "This socket is closed.") {
+                    killProcess();
+                }
+                else {
+                    handleError("sending cmmand", ex.emssage);
+                }
+                reject(ex.message);
+            }
+        });
+    }
+}
+
+function getNextCommandId(): number {
+    return cmdId++;
+}
+
+function spawnProcess(dir: string) {
+
+    try {
+        proc = cp.spawn(juliaPath, ["completion.jl"], { cwd: dir });
+    }
+    catch (ex) {
+        return handleError("spawnProcess", ex.message);
+    }
+
+    proc.stderr.on("data", (data) => {
+        //vscode.window.showErrorMessage(data.toString());
+        console.log(data.toString());
+    });
+
+    proc.on("end", (end) => {
+        console.log("spawnProcess.end", "End - " + end);
+    });
+
+    proc.on("error", (error) => {
+        handleError("error", error);
+    });
+
+    proc.stdout.on("data", (data) => {
+        handleResponse(data);
+    });
+}
+
+function handleResponse(data) {
+    var dataStr: string = previousData = previousData + data + "";
+    if (dataStr[0] !== "{") {
+        previousData = "";
+        return;
+    }    
+    var responses: any;
+    try {
+        responses = dataStr.split(/\r?\n/g).filter(line => line.length > 0).map(resp => JSON.parse(resp));
+        previousData = "";
+    }
+    catch (ex) {
+        if (ex.message !== 'Unexpected end of input') {
+            handleError("stdout", ex.message);
+        }
+        return;
+    }
+    if (typeof responses !== 'object') {
+        console.log(responses);
+        return;
+    }
+    responses.forEach((response) => {
+        if (typeof response === 'object') {
+            let responseId = <number>response["id"];
+            if (responseId < 0) {
+                vscode.window.showInformationMessage("Result: " + response['results']);
+            }
+            let cmd = <ICommand>commands.get(responseId);
+            if (typeof cmd === "object" && cmd !== null) {
+                commands.delete(responseId);
+                let index = commandQueue.indexOf(cmd.id);
+                commandQueue.splice(index, 1);
+                switch (cmd.commandType) {
+                    case "completion": {
+                        let results = response['results'];
+                        let suggestions: vscode.CompletionItem[] = [];
+                        for (let i = 0; i < results.length; i++) {
+                            let resItem = <IResultItem>results[i];
+                            if (typeof results[i] === "object") {
+                                let item = new vscode.CompletionItem(resItem.text);
+                                item.kind = juliaVSCodeTypeMapping.get(resItem.type);
+                                if (resItem.displayText) {
+                                    item.label = resItem.displayText;
+                                }
+                                let insertText = resItem.text;
+                                if (insertText.startsWith("@")) {
+                                    insertText = insertText.substr(1);
+                                }
+                                item.insertText = insertText;
+                                if (resItem.description) {
+                                    item.detail = resItem.description
+                                }
+                                suggestions.push(item);
+                            }
+                            else if (typeof results[i] === "string") {
+                                let item = new vscode.CompletionItem(results[i]);
+                                item.kind = juliaVSCodeTypeMapping.get('keyword');
+                                suggestions.push(item);
+                            }
+                        }
+                        cmd.resolve(suggestions);
+                    }
+                }
+            }
+        }
+    });
+    return;
+}
+
+function initialize(dir: string) {
+    juliaProcessCWD = dir;
+    spawnProcess(path.join(dir, "scripts"));
+}
+
+function killProcess() {
+    try {
+        if (proc) {
+            proc.kill();
+        }
+    }
+    catch (ex) {
+        proc = null;
+    }
+}
+
+function clearPendingRequests() {
+    commandQueue = [];
+    commands.forEach(item => {
+        item.resolve();
+    });
+    commands.clear();
+}
+
+function handleError(source: string, errorMessage: string) {
+    //TO DO 
+    console.log(source + "; " + errorMessage);
+}
+
+interface IAutoCompletionItem {
+    type: vscode.CompletionItemKind;
+    kind: vscode.SymbolKind;
+    text: string;
+    description: string;
+    rightLbel: string;
+}
+
+// interface for the command in the command queue
+interface ICommand {
+    id: number;
+    commandType: string;
+    resolve: (value?: any) => void;
+    reject: (ICommandError) => void;
+    token: vscode.CancellationToken;
+}
+
+// Interface of the request which is send to the server
+interface IRequest {
+    id?: number;
+    requestType: string;
+    source: string;
+    fileName?: string;
+    lineIndex?: number;
+    columnIndex?: number;
+}
+
+interface ICommandError {
+    message: string;
+}
+
+interface IResultItem {
+    text: string;
+    type: string;
+    description?: string;
+    displayText?: string;
+    rightLabel?: string;
+}
+
+const juliaVSCodeTypeMapping = new Map<string, vscode.CompletionItemKind>();
+juliaVSCodeTypeMapping.set('keyword', vscode.CompletionItemKind.Keyword);
+juliaVSCodeTypeMapping.set('package', vscode.CompletionItemKind.Module);
+juliaVSCodeTypeMapping.set('λ', vscode.CompletionItemKind.Function);
+juliaVSCodeTypeMapping.set('constant', vscode.CompletionItemKind.Variable);
+juliaVSCodeTypeMapping.set('macro', vscode.CompletionItemKind.Function);
+juliaVSCodeTypeMapping.set('type', vscode.CompletionItemKind.Class);
+
+
+export function executeJuliaCode() {
+    if (!proc) {
+        handleError("ExecuteJulia", "Julia is not running");
+        return;
+    }
+    let editor = vscode.window.activeTextEditor;
+    if (!editor) {
+        return;
+    }
+
+    let selection = editor.selection;
+    var text = selection.isEmpty ? editor.document.lineAt(selection.start.line).text : editor.document.getText(selection);
+    // If no text was selected, try to move the cursor to the end of the next line
+    if (selection.isEmpty) {
+        for (var line = selection.start.line + 1; line < editor.document.lineCount; line++) {
+            if (!editor.document.lineAt(line).isEmptyOrWhitespace) {
+                var newPos = selection.active.with(line, editor.document.lineAt(line).range.end.character);
+                var newSel = new vscode.Selection(newPos, newPos);
+                editor.selection = newSel;
+                break;
+            }
+        }
+    }
+    //text = text.replace(/\"/g, '\\\"');
+    let request: IRequest = {
+        requestType: 'evaluation',
+        source: text
+    };
+    try {
+        proc.stdin.write(JSON.stringify(request) + "\n");
+    }
+    catch (ex) {
+        if (ex.message === "This socket is closed.") {
+            killProcess();
+        }
+        else {
+            handleError("sending cmmand", ex.emssage);
+        }
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,9 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as net from 'net';
 import JuliaValidationProvider from './linter';
+import { JuliaCompletionItemProvider, executeJuliaCode} from './completionprovider';
 
+const JULIA: vscode.DocumentFilter = { language: 'julia', scheme: 'file' };
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
@@ -15,6 +17,7 @@ export function activate(context: vscode.ExtensionContext) {
     // This line of code will only be executed once when your extension is activated
     console.log('Activating extension language-julia');
 
+
     // The command has been defined in the package.json file
     // Now provide the implementation of the command with  registerCommand
     // The commandId parameter must match the command field in package.json
@@ -22,8 +25,14 @@ export function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(disposable);
 
-    let validator = new JuliaValidationProvider();
-	validator.activate(context);
+    //let validator = new JuliaValidationProvider();
+	//validator.activate(context);
+
+    let juliaCompletionProvider = new JuliaCompletionItemProvider(context);
+    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(JULIA, juliaCompletionProvider, '.', '\"', '@'));
+
+    let disposable2 = vscode.commands.registerCommand('language-julia.executeCode', executeJuliaCode);
+    context.subscriptions.push(disposable2);
 }
 
 // this method is called when your extension is deactivated


### PR DESCRIPTION
Features:
+ repl based autocompletion. Also the same as working with REPL.
+ execute julia code via command "julia: Execute Code" on command prompt. This can be used, for example to import modules for auto-completion and to added user defined types and functions into julia for autocompletion on user file to work.

Next:
- julia must be in PATH -> to be improved
- still no feedback when perform code execution -> to be added.
- goto definition may be implemented by using @less or @functionloc macros in the REPL.