### PR TITLE
Add server and hoverprovider

### DIFF
--- a/jl/server.jl
+++ b/jl/server.jl
@@ -1,0 +1,22 @@
+using JSON
+server = listen("juliaserver"*string(getpid()))
+
+hover(sock,request) = write(sock,JSON.json(Dict(
+                        "id"=>request["id"],
+                        "type"=>"hover",
+                        "doc"=>string(Docs.doc(getfield(Main,Symbol(request["params"]))))
+                    )))
+
+while true
+    sock = accept(server)
+    @async while isopen(sock)
+        msg = readline(sock)
+        try 
+            request = JSON.Parser.parse(msg)
+            if request["type"] == "hover"
+                hover(sock,request)
+            end
+        end
+    end
+end
+

--- a/jl/server.jl
+++ b/jl/server.jl
@@ -1,5 +1,34 @@
-using JSON
+using JSON,JuliaParser
 server = listen("juliaserver"*string(getpid()))
+
+function getfullname(line::String,pos::Int)
+    s = e = max(1,pos)
+    while e<=length(line) && Lexer.is_identifier_char(line[e])
+        e+=1
+    end
+    while s>0 && (Lexer.is_identifier_char(line[s]) || line[s]=='.')
+        s-=1
+    end
+    ret = line[s+1:e-1]
+    ret = ret[1] == '.' ? ret[2:end] : ret
+    return ret 
+end
+
+function definition(sock,request)
+    line = request["params"]["line"]
+    pos = request["params"]["pos"]
+    name = split(getfullname(line,pos),'.')
+    x = getfield(Main,Symbol(name[1]))
+    for i = 2:length(name)
+        x = getfield(x,Symbol(name[i]))
+    end
+    ms =map(functionloc,methods(x).ms)
+    write(sock,JSON.json(Dict(
+        "id"=>request["id"],
+        "type"=>"definition",
+        "defs"=>ms 
+    )))
+end
 
 hover(sock,request) = write(sock,JSON.json(Dict(
                         "id"=>request["id"],
@@ -15,6 +44,8 @@ while true
             request = JSON.Parser.parse(msg)
             if request["type"] == "hover"
                 hover(sock,request)
+            elseif request["type"] == "definition"
+                definition(sock,request)
             end
         end
     end

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -1,0 +1,39 @@
+'use strict';
+import { CompletionItemProvider, CompletionItem, TextDocument, Position, Range, CancellationToken, Uri } from 'vscode';
+import { JuliaSocket, Request } from './server';
+
+import * as net from 'net';
+
+export class JuliaCompletionItemProvider implements CompletionItemProvider {
+	private socket: JuliaSocket;
+	public constructor(socket: JuliaSocket) {
+		this.socket = socket;
+	}
+    public handle(result) {
+        
+        return result.completionitems.map((item)=>{
+            return new CompletionItem(item)
+        });
+    }
+
+	public provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken): Promise<CompletionItem[]> {
+        return new Promise<CompletionItem[]> ((resolve,reject)=>{
+            if (position.character <= 0) {
+                return resolve();
+            }
+            let line = document.getText(document.lineAt(position.line).range)
+            
+            var req = <Request>{
+                type: 'completions',
+                params: {
+                        line: line,
+                        pos: position.character
+                },
+                resolve: resolve,
+                handle: this.handle
+            }
+            this.socket.send(req)
+        });
+    }
+}
+

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -1,0 +1,40 @@
+'use strict';
+import { DefinitionProvider, Definition, TextDocument, Position, Range, CancellationToken, Uri, Location } from 'vscode';
+import { JuliaSocket, Request } from './server';
+
+import * as net from 'net';
+
+export class JuliaDefinitionProvider implements DefinitionProvider {
+	private socket: JuliaSocket;
+
+	public constructor(socket: JuliaSocket) {
+		this.socket = socket;
+	}
+
+    public handle(result) {
+        return result.defs.map((def)=>{
+            return new Location(Uri.file(def[0]), new Range(def[1]-1, 0, def[1]-1, 0));
+        });
+    }
+
+	public provideDefinition(document: TextDocument, position: Position, token: CancellationToken): Promise<Definition> {
+        return new Promise<Definition> ((resolve,reject)=>{
+            if (position.character <= 0) {
+                return resolve();
+            }
+            let line = document.getText(document.lineAt(position.line).range)
+            
+            var req = <Request>{
+                type: 'definition',
+                params: {
+                        line: line,
+                        pos: position.character
+                },
+                resolve: resolve,
+                handle: this.handle
+            }
+            this.socket.send(req)
+        });
+    }
+}
+

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,13 @@ import * as vscode from 'vscode';
 import * as fs from 'fs'
 import * as path from 'path'
 import * as net from 'net';
+import * as cp from 'child_process';
 import JuliaValidationProvider from './linter';
+import { JuliaServer, JuliaSocket } from './server';
+import { JuliaHoverProvider } from './hover';
+
+var jserver: JuliaServer;
+var jsocket: JuliaSocket;
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -22,6 +28,10 @@ export function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(disposable);
 
+    jserver = new JuliaServer(context);
+    jsocket = new JuliaSocket(context)
+
+    context.subscriptions.push(vscode.languages.registerHoverProvider("julia", new JuliaHoverProvider(jsocket)))
     let validator = new JuliaValidationProvider();
 	validator.activate(context);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import JuliaValidationProvider from './linter';
 import { JuliaServer, JuliaSocket } from './server';
 import { JuliaHoverProvider } from './hover';
 import { JuliaDefinitionProvider } from './definition';
+import { JuliaCompletionItemProvider } from './completions';
 
 var jserver: JuliaServer;
 var jsocket: JuliaSocket;
@@ -34,6 +35,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(vscode.languages.registerHoverProvider("julia", new JuliaHoverProvider(jsocket)))
     context.subscriptions.push(vscode.languages.registerDefinitionProvider("julia", new JuliaDefinitionProvider(jsocket)))
+    context.subscriptions.push(vscode.languages.registerCompletionItemProvider("julia", new JuliaCompletionItemProvider(jsocket),'(','.'))
     let validator = new JuliaValidationProvider();
 	validator.activate(context);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import * as cp from 'child_process';
 import JuliaValidationProvider from './linter';
 import { JuliaServer, JuliaSocket } from './server';
 import { JuliaHoverProvider } from './hover';
+import { JuliaDefinitionProvider } from './definition';
 
 var jserver: JuliaServer;
 var jsocket: JuliaSocket;
@@ -32,6 +33,7 @@ export function activate(context: vscode.ExtensionContext) {
     jsocket = new JuliaSocket(context)
 
     context.subscriptions.push(vscode.languages.registerHoverProvider("julia", new JuliaHoverProvider(jsocket)))
+    context.subscriptions.push(vscode.languages.registerDefinitionProvider("julia", new JuliaDefinitionProvider(jsocket)))
     let validator = new JuliaValidationProvider();
 	validator.activate(context);
 }

--- a/src/hover.ts
+++ b/src/hover.ts
@@ -1,0 +1,32 @@
+'use strict';
+import { HoverProvider, Hover, TextDocument, Position, Range, CancellationToken } from 'vscode';
+import { JuliaSocket, Request } from './server';
+
+import * as net from 'net';
+
+export class JuliaHoverProvider implements HoverProvider {
+	private socket: JuliaSocket;
+
+	public constructor(socket: JuliaSocket) {
+		this.socket = socket;
+	}
+
+    public handle(result) {
+        return new Hover({language: "julia", value:result.doc})
+    }
+
+	public provideHover(document: TextDocument, position: Position, token: CancellationToken): Promise<Hover> {
+        return new Promise<Hover> ((resolve,reject)=>{
+            let text = document.getText(document.getWordRangeAtPosition(position))
+
+            var req = <Request>{
+                type: 'hover',
+                params: text,
+                resolve: resolve,
+                handle: this.handle
+            }
+            this.socket.send(req)
+        });
+    }
+}
+

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,110 @@
+'use strict';
+import * as vscode from 'vscode';
+import * as cp from 'child_process';
+import * as net from 'net';
+
+let jproc: cp.ChildProcess;
+let jsock: net.Socket;
+let requests = new Map<number,Request>();
+
+export interface Request {
+    id?: number,
+    type: string,
+    params,
+    resolve,
+    handle
+}
+
+export class JuliaServer extends vscode.Disposable {
+    public proc
+    public kill(){ 
+        killJuliaServer();
+    }
+    public restart() {
+        this.kill();
+        startJuliaServer();
+    }
+    public constructor(context: vscode.ExtensionContext) {
+        super(killJuliaServer)
+        context.subscriptions.push(this)
+        this.proc = startJuliaServer()
+    }
+}
+
+function killJuliaServer() {
+    try { 
+        if (jproc) {
+            jproc.kill('SIGKILL');
+        }
+    }
+    catch (err) {
+        jproc=null;
+    }
+}
+
+export function startJuliaServer(){
+    try {
+        let jbin = vscode.workspace.getConfiguration('julia').get<string>("validate.executablePath",'julia');
+        let jserver = vscode.extensions.getExtension("julialang.language-julia").extensionPath+"/jl/server.jl"
+
+        jproc = cp.spawn(jbin,[jserver]);
+        jproc.stdout.on("data",(dat)=>{
+            console.log(dat);
+        })
+        jproc.stderr.on("error",(err)=>{console.log(err)})
+        return jproc
+    }
+    catch (err) {
+        console.log(err);
+    }
+}
+
+
+export class JuliaSocket extends vscode.Disposable {
+    private requestid: number = 0;
+    public socket: net.Socket;
+    public on: boolean = false;
+    public constructor(context: vscode.ExtensionContext) {
+        super(closesocket)
+        context.subscriptions.push(this)
+        this.socket = new net.Socket
+        this.socket.on('data',this.receive)
+        this.socket.on('error',(data)=>{console.log(data.toString())})
+    }
+
+    public send(req: Request){
+        if (!this.on) {
+            this.connect()
+        }
+        this.requestid++
+        req.id = this.requestid
+        requests.set(this.requestid,req)
+        
+        this.socket.write(JSON.stringify({
+                type: req.type,
+                params: req.params,
+                id: req.id
+            })+'\n')
+    }
+
+    public receive(data) {
+        let result = JSON.parse(data.toString())
+        let request = requests.get(result.id)
+
+        request.resolve(request.handle(result))
+    }
+
+    public connect() {
+        try {
+            this.socket.connect("juliaserver"+jproc.pid);
+            this.on = true;
+        }
+        catch (err) {
+            console.log("err")
+        }
+    }
+}
+
+function closesocket() { 
+    jsock.destroy();
+}


### PR DESCRIPTION
This rewrites the server backend simplifying the interface somewhat and uses a named pipe rather than STDIO.

I've rewritten the server side to use a pipe as was suggested. This should prevent any possible interference of modules printing output on load and may allow some sort of direct interface with server to provide output in the future.

The interface between various providers and the server is now more modular, the server simply receives a request and sends back the result without doing any parsing of that result, leaving it to the (in this case) JuliaHoverProvider class to do what it will with the returned data.

There may be some drawback to this approach but I can't see them atm.

