### PR TITLE
signatures run through arguments and don't crash

### DIFF
--- a/scripts/languageserver/utilities.jl
+++ b/scripts/languageserver/utilities.jl
@@ -13,6 +13,7 @@ function get_word(p::TextDocumentPositionParams, server::LanguageServer, offset=
         s-=1
     end
     ret = line[s+1:e-1]
+    ret =="" && (return "")
     ret = ret[1] == '.' ? ret[2:end] : ret
     return ret 
 end


### PR DESCRIPTION
fixes signatures and I uncovered a bug in get_word that caused hovers to crash when hovering brackets and other special characters