### PR TITLE
Clean up hovers

### DIFF
--- a/scripts/languageserver/protocol.jl
+++ b/scripts/languageserver/protocol.jl
@@ -25,9 +25,14 @@ end
 Location(d::Dict) = Location(d["uri"],Range(d["range"]))
 Location(f::String,line::Integer) = Location(f,Range(line))
 
+type MarkedString
+    language::String
+    value::AbstractString
+end
+MarkedString(x) = MarkedString("julia",x)
 
 type Hover
-    contents::Vector{String}
+    contents::Vector{Union{AbstractString,MarkedString}}
 end
 
 type CompletionItem

--- a/scripts/languageserver/protocol.jl
+++ b/scripts/languageserver/protocol.jl
@@ -4,7 +4,7 @@ type Position
     character::Int
 end
 Position(d::Dict) = Position(d["line"],d["character"])
-Position(line) = Position(line,0)
+Position(line::Integer) = Position(line,0)
 Position() = Position(-1,-1)
 
 let ex=:(type Range
@@ -15,16 +15,15 @@ let ex=:(type Range
     ex.args[3].args[2].args[1]=Symbol("end")
     eval(ex)
 end
-
 Range(d::Dict) = Range(Position(d["start"]),Position(d["end"]))
-Range(line) = Range(Position(line),Position(line))
+Range(line::Integer) = Range(Position(line),Position(line))
 
 type Location
     uri::String
     range::Range
 end
 Location(d::Dict) = Location(d["uri"],Range(d["range"]))
-Location(f::String,line) = Location(f,Range(line))
+Location(f::String,line::Integer) = Location(f,Range(line))
 
 
 type Hover
@@ -107,15 +106,15 @@ end
 
 type TextDocumentIdentifier
     uri::String
-    TextDocumentIdentifier(d::Dict) = new(d["uri"])
 end
+TextDocumentIdentifier(d::Dict) = TextDocumentIdentifier(d["uri"])
 
 
 type VersionedTextDocumentIdentifier
     uri::String
     version::Int
-    VersionedTextDocumentIdentifier(d::Dict) = new(d["uri"],d["version"])
 end
+VersionedTextDocumentIdentifier(d::Dict) = VersionedTextDocumentIdentifier(d["uri"],d["version"])
 
 
 
@@ -132,8 +131,8 @@ TextDocumentContentChangeEvent(d::Dict) = TextDocumentContentChangeEvent(d["text
 type DidChangeTextDocumentParams
     textDocument::VersionedTextDocumentIdentifier
     contentChanges::Vector{TextDocumentContentChangeEvent}
-    DidChangeTextDocumentParams(d::Dict) = new(VersionedTextDocumentIdentifier(d["textDocument"]),TextDocumentContentChangeEvent.(d["contentChanges"]))
 end
+DidChangeTextDocumentParams(d::Dict) = DidChangeTextDocumentParams(VersionedTextDocumentIdentifier(d["textDocument"]),TextDocumentContentChangeEvent.(d["contentChanges"]))
 
 
 type TextDocumentItem
@@ -141,32 +140,32 @@ type TextDocumentItem
     languageId::String
     version::Int
     text::String
-    TextDocumentItem(d::Dict) = new(d["uri"],d["languageId"],d["version"],d["text"])
 end
+TextDocumentItem(d::Dict) = TextDocumentItem(d["uri"],d["languageId"],d["version"],d["text"])
 
 
 type TextDocumentPositionParams
     textDocument::TextDocumentIdentifier
     position::Position
-    TextDocumentPositionParams(d::Dict) = new(TextDocumentIdentifier(d["textDocument"]),Position(d["position"]))
 end
+TextDocumentPositionParams(d::Dict) = TextDocumentPositionParams(TextDocumentIdentifier(d["textDocument"]),Position(d["position"]))
 
 type DidOpenTextDocumentParams
     textDocument::TextDocumentItem
-    DidOpenTextDocumentParams(d::Dict) = new(TextDocumentItem(d["textDocument"]))
 end
+DidOpenTextDocumentParams(d::Dict) = DidOpenTextDocumentParams(TextDocumentItem(d["textDocument"]))
 
 type DidCloseTextDocumentParams
     textDocument::TextDocumentIdentifier
-    DidCloseTextDocumentParams(d::Dict) = new(TextDocumentIdentifier(d["textDocument"]))
 end
+DidCloseTextDocumentParams(d::Dict) = DidCloseTextDocumentParams(TextDocumentIdentifier(d["textDocument"]))
 
 type DidSaveTextDocumentParams
     textDocument::TextDocumentIdentifier
-    DidSaveTextDocumentParams(d::Dict) = new(TextDocumentIdentifier(d["textDocument"]))
 end
+DidSaveTextDocumentParams(d::Dict) = DidSaveTextDocumentParams(TextDocumentIdentifier(d["textDocument"]))
 
 type CancelParams
     id::Union{String,Int}
-    CancelParams(d::Dict) = new(d["id"])
 end
+CancelParams(d::Dict) = CancelParams(d["id"])

--- a/scripts/languageserver/utilities.jl
+++ b/scripts/languageserver/utilities.jl
@@ -53,20 +53,20 @@ function get_docs(x)
         if isa(x,DataType)
             s1 = last(search(str,"\n\n```\n",e))+1
             e1 = first(search(str,"\n```",s1))-1
-            d = vcat(str[s:e], split(str[s1:e1],'\n'))
+            d = MarkedString.(split(chomp(sprint(dump,x)),'\n'))
         elseif isa(x,Function)
             d = split(str[s:e],'\n')
             s = last(search(str,"\n\n"))+1
             e = first(search(str,"\n\n",s))-1
-            d = map(dd->(dd = dd[1:first(search(dd," in "))-1]),d)
-            d[1] = str[s:e]
+            d = MarkedString.(map(dd->(dd = dd[1:first(search(dd," in "))-1]),d))
+            d[1] = MarkedString(str[s:e])
         elseif isa(x,Module)
             d = [split(str,'\n')[3]]
         else
             d = [""]
         end
     else
-        d = split(str,"\n\n")
+        d = split(str,"\n\n",limit=2)
     end
     return d
 end

--- a/scripts/languageserver/utilities.jl
+++ b/scripts/languageserver/utilities.jl
@@ -1,11 +1,11 @@
-function get_line(p::TextDocumentPositionParams, server::LanguageServer)
-    d = server.documents[p.textDocument.uri]
-    return d[p.position.line+1]
+function get_line(tdpp::TextDocumentPositionParams, server::LanguageServer)
+    d = server.documents[tdpp.textDocument.uri]
+    return d[tdpp.position.line+1]
 end
 
-function get_word(p::TextDocumentPositionParams, server::LanguageServer, offset=0)
-    line = get_line(p, server)
-    s = e = max(1,p.position.character)+offset
+function get_word(tdpp::TextDocumentPositionParams, server::LanguageServer, offset=0)
+    line = get_line(tdpp, server)
+    s = e = max(1,tdpp.position.character)+offset
     while e<=length(line) && Lexer.is_identifier_char(line[e])
         e+=1
     end
@@ -20,18 +20,18 @@ end
 
 function get_sym(str::String)
     name = split(str,'.')
+    x =  nothing
     try
         x = getfield(Main,Symbol(name[1]))
         for i = 2:length(name)
             x = getfield(x,Symbol(name[i]))
         end
-        return x
     catch
-        return nothing
     end
+    return x
 end
 
-get_sym(p::TextDocumentPositionParams, server::LanguageServer) = get_sym(get_word(p, server))
+get_sym(tdpp::TextDocumentPositionParams, server::LanguageServer) = get_sym(get_word(tdpp, server))
 
 function get_docs(x)
     str = string(Docs.doc(x))

--- a/scripts/languageserver/utilities.jl
+++ b/scripts/languageserver/utilities.jl
@@ -50,7 +50,7 @@ function get_docs(x)
     if str[1:16]=="No documentation"
         s = last(search(str,"\n\n```\n"))+1
         e = first(search(str,"\n```",s))-1
-        if isa(x,DataType)
+        if isa(x,DataType) && x!=Any
             s1 = last(search(str,"\n\n```\n",e))+1
             e1 = first(search(str,"\n```",s1))-1
             d = MarkedString.(split(chomp(sprint(dump,x)),'\n'))


### PR DESCRIPTION
cleans up the hovers provider. Also replaces `get_word` which was crashing before on encountering unicode characters