### PR TITLE
store cache of generated symbol documents 

### DIFF
--- a/scripts/languageserver/languageserver.jl
+++ b/scripts/languageserver/languageserver.jl
@@ -3,9 +3,10 @@ type LanguageServer
     pipe_out
 
     documents::Dict{String,Array{String,1}}
+    DocStore::Dict{String,Any}
 
     function LanguageServer(pipe_in,pipe_out)
-        new(pipe_in,pipe_out,Dict{String,Array{String,1}}())
+        new(pipe_in,pipe_out,Dict{String,Array{String,1}}(),Dict{String,Any}())
     end
 end
 

--- a/scripts/languageserver/utilities.jl
+++ b/scripts/languageserver/utilities.jl
@@ -59,4 +59,15 @@ function get_docs(x)
     return d
 end
 
-get_docs(tdpp::TextDocumentPositionParams, server::LanguageServer) = get_docs(get_sym(tdpp, server))
+function get_docs(tdpp::TextDocumentPositionParams, server::LanguageServer)
+    word = get_word(tdpp,server)
+    in(word,keys(server.DocStore)) && (return server.DocStore[word])
+    sym = get_sym(word)
+    d=[""]
+    if sym!=nothing
+        d = get_docs(sym)
+        server.DocStore[word] = d
+    end
+    return d
+end
+

--- a/scripts/languageserver/utilities.jl
+++ b/scripts/languageserver/utilities.jl
@@ -66,6 +66,12 @@ function get_docs(tdpp::TextDocumentPositionParams, server::LanguageServer)
     d=[""]
     if sym!=nothing
         d = get_docs(sym)
+        # Only keep 100 records
+        if length(server.DocStore)>100
+            for k in take(keys(server.DocStore),10)
+                delete!(server.DocStore,k)
+            end
+        end
         server.DocStore[word] = d
     end
     return d


### PR DESCRIPTION
Creates a cache of 100 documentation items.

Accessing hovers/completions on random areas of a .jl file in base this gives a ~x10 speed increase on the server side.

When the `Dict` exceeds 100 items 10 at random (ish) are deleted. We could rank how frequently each item is used and delete based on that but it doesn't seem worth it.