### PR TITLE
Add debug mode option to language server

### DIFF
--- a/scripts/languageserver/main.jl
+++ b/scripts/languageserver/main.jl
@@ -14,10 +14,16 @@ use_and_install_dependencies([
     ("URIParser", v"0.0.5"),
     ("JuliaParser",v"0.7.4")])
 
-if length(Base.ARGS)==1
-    push!(LOAD_PATH, Base.ARGS[1])
-elseif length(Base.ARGS)>1
+if length(Base.ARGS)!=2
     error("Invalid number of arguments passed to julia language server.")
+end
+
+push!(LOAD_PATH, Base.ARGS[1])
+
+if Base.ARGS[2]=="--debug=no"
+    const global ls_debug_mode = false
+elseif Base.ARGS[2]=="--debug=yes"
+    const global ls_debug_mode = true
 end
 
 include("jsonrpc.jl")

--- a/scripts/languageserver/transport.jl
+++ b/scripts/languageserver/transport.jl
@@ -14,8 +14,8 @@ function read_transport_layer(stream)
 
     message = read(stream, message_length)
     message_str = String(message)
-    info("RECEIVED: $message_str")
-    info()
+    ls_debug_mode && info("RECEIVED: $message_str")
+    ls_debug_mode && info()
     return message_str    
 end
 
@@ -24,6 +24,6 @@ function write_transport_layer(stream, response)
     n = length(response_utf8)
     write(stream, "Content-Length: $n\r\n\r\n")
     write(stream, response_utf8)
-    info("SENT: $response")
-    info()
+    ls_debug_mode && info("SENT: $response")
+    ls_debug_mode && info()
 end

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -77,10 +77,9 @@ async function getPkgPath() {
 }
 
 async function startLanguageServer(context: vscode.ExtensionContext) {
-    // let debugOptions = { execArgv: ["--nolazy", "--debug=6004"] };
-
     var originalJuliaPkgDir = await getPkgPath();
-    let serverArgs = ['--startup-file=no', '--history-file=no', 'main.jl', originalJuliaPkgDir];
+    let serverArgsRun = ['--startup-file=no', '--history-file=no', 'main.jl', originalJuliaPkgDir, '--debug=no'];
+    let serverArgsDebug = ['--startup-file=no', '--history-file=no', 'main.jl', originalJuliaPkgDir, '--debug=yes'];
     let spawnOptions = {
         cwd: path.join(context.extensionPath, 'scripts', 'languageserver'),
         env: {
@@ -90,8 +89,8 @@ async function startLanguageServer(context: vscode.ExtensionContext) {
     };
 
     let serverOptions = {
-        run: { command: juliaExecutable, args: serverArgs, options: spawnOptions },
-        debug: { command: juliaExecutable, args: serverArgs, options: spawnOptions }
+        run: { command: juliaExecutable, args: serverArgsRun, options: spawnOptions },
+        debug: { command: juliaExecutable, args: serverArgsDebug, options: spawnOptions }
     };
 
     let clientOptions: LanguageClientOptions = {


### PR DESCRIPTION
This should hide the raw JSON traffic if the extension is not running under the debugger.