### PR TITLE
Rename Range fieldname

### DIFF
--- a/scripts/languageserver/parse.jl
+++ b/scripts/languageserver/parse.jl
@@ -22,7 +22,7 @@ function Block(utd, ex, r::Range)
     t, name, doc, lvars = classify_expr(ex)
     ctx = LintContext()
     ctx.lineabs = r.start.line+1
-    dl = r.end.line-r.start.line-ctx.line
+    dl = r.stop.line-r.start.line-ctx.line
     # Lint.lintexpr(ex, ctx)
     # diags = map(ctx.messages) do l
     #     return Diagnostic(Range(Position(r.start.line+l.line+dl-1, 0), Position(r.start.line+l.line+dl-1, 100)),
@@ -83,7 +83,7 @@ function parseblocks(uri::String, server::LanguageServer, updateall=false)
                 out = vcat(out,blocks[inextgood+1:end])
                 for i  = inextgood+1:length(out)
                     out[i].range.start.line += dl
-                    out[i].range.end.line += dl
+                    out[i].range.stop.line += dl
                 end
                 break
             end
@@ -171,9 +171,9 @@ end
 import Base:<, in, intersect
 <(a::Position, b::Position) =  a.line<b.line || (a.line≤b.line && a.character<b.character)
 function in(p::Position, r::Range)
-    (r.start.line < p.line < r.end.line) ||
+    (r.start.line < p.line < r.stop.line) ||
     (r.start.line == p.line && r.start.character ≤ p.character) ||
-    (r.end.line == p.line && p.character ≤ r.end.character)  
+    (r.stop.line == p.line && p.character ≤ r.stop.character)  
 end
 
 intersect(a::Range, b::Range) = a.start in b || b.start in a

--- a/scripts/languageserver/protocol.jl
+++ b/scripts/languageserver/protocol.jl
@@ -12,6 +12,14 @@ type Range
     stop::Position # mismatch between vscode-ls protocol naming (should be 'end')
 end
 
+function JSON._writejson(io::IO, state::JSON.State, a::Range)
+    Base.print(io,"{\"start\":")
+    JSON._writejson(io,state,a.start)
+    Base.print(io,",\"end\":")
+    JSON._writejson(io,state,a.stop)
+    Base.print(io,"}")
+end
+
 Range(d::Dict) = Range(Position(d["start"]), Position(d["end"]))
 Range(line) = Range(Position(line), Position(line))
 

--- a/scripts/languageserver/protocol.jl
+++ b/scripts/languageserver/protocol.jl
@@ -7,13 +7,9 @@ Position(d::Dict) = Position(d["line"], d["character"])
 Position(line) = Position(line,0)
 Position() = Position(-1, -1)
 
-let ex=:(type Range
-        start::Position
-        finish::Position
-    end)
-    ex.args[3].args=ex.args[3].args[[2;4]]
-    ex.args[3].args[2].args[1]=Symbol("end")
-    eval(ex)
+type Range
+    start::Position
+    stop::Position # mismatch between vscode-ls protocol naming (should be 'end')
 end
 
 Range(d::Dict) = Range(Position(d["start"]), Position(d["end"]))

--- a/scripts/languageserver/provider_misc.jl
+++ b/scripts/languageserver/provider_misc.jl
@@ -54,7 +54,7 @@ function process(r::Request{Val{Symbol("textDocument/didChange")},DidChangeTextD
         end 
         startpos = position(io) 
         seek(io, endline) 
-        while e<c.range.end.character 
+        while e<c.range.stop.character 
             e += 1 
             read(io, Char) 
         end 

--- a/scripts/languageserver/utilities.jl
+++ b/scripts/languageserver/utilities.jl
@@ -99,7 +99,7 @@ function get_docs(tdpp::TextDocumentPositionParams, server::LanguageServer)
 end
 
 function get_rangelocs(d::Array{UInt8}, range::Range)
-    (s,e) = (range.start.line, range.end.line)
+    (s,e) = (range.start.line, range.stop.line)
     n = length(d)
     i = cnt = 0
     while cnt<s && i<n


### PR DESCRIPTION
This is ... slightly dodgy but I offer it as a suggestion for fixing the linting issue.

Maybe the lesser of two evils (the other being the `eval` of modified Range type definition).