### PR TITLE
move parseblocks to correct function

### DIFF
--- a/scripts/languageserver/provider_misc.jl
+++ b/scripts/languageserver/provider_misc.jl
@@ -83,11 +83,11 @@ function JSONRPC.parse_params(::Type{Val{Symbol("\$/cancelRequest")}}, params)
 end
 
 function process(r::Request{Val{Symbol("textDocument/didSave")},DidSaveTextDocumentParams}, server)
-    
+    parseblocks(r.params.textDocument.uri, server, true)
 end
 
 
 function JSONRPC.parse_params(::Type{Val{Symbol("textDocument/didSave")}}, params)
-    parseblocks(r.params.textDocument.uri, server, true)
+    
     return DidSaveTextDocumentParams(params)
 end


### PR DESCRIPTION
move `parseblocks(.)` from `parse_params` to `process` 