### PR TITLE
remove JuliaParser dependency

### DIFF
--- a/scripts/languageserver/main.jl
+++ b/scripts/languageserver/main.jl
@@ -7,12 +7,10 @@ end
 
 include("dependencies.jl")
 use_and_install_dependencies([
-    ("AbstractTrees", v"0.0.4"),
     ("Compat", v"0.9.4"),
     ("JSON", v"0.8.0"),
     ("Lint", v"0.2.5"),
-    ("URIParser", v"0.1.6"),
-    ("JuliaParser",v"0.7.4")])
+    ("URIParser", v"0.1.6")])
 
 if length(Base.ARGS)!=2
     error("Invalid number of arguments passed to julia language server.")

--- a/scripts/languageserver/utilities.jl
+++ b/scripts/languageserver/utilities.jl
@@ -36,8 +36,8 @@ function get_word(tdpp::TextDocumentPositionParams, server::LanguageServer, offs
         c = read(line, Char)
         Base.is_id_char(c) && push!(word, c)
     end
-    for i = 1:2 # Delete junk at front
-        !isempty(word) && word[1] in [' ','.','!'] && deleteat!(word, 1)
+    for i = 1:5 # Delete junk at front
+        !isempty(word) && (word[1] in [' ','.','!'] || '0'≤word[1]≤'9') && deleteat!(word, 1)
     end
     isempty(word) && return ""
     return String(word)

--- a/scripts/languageserver/utilities.jl
+++ b/scripts/languageserver/utilities.jl
@@ -26,15 +26,15 @@ function get_word(tdpp::TextDocumentPositionParams, server::LanguageServer, offs
         e += 1
         c = read(line, Char)
         push!(word, c)
-        if !(Lexer.is_identifier_char(c) || c=='.')
+        if !(Base.is_id_char(c) || c=='.')
             word = Char[]
             s = e
         end
     end
-    while !eof(line) && Lexer.is_identifier_char(c)
+    while !eof(line) && Base.is_id_char(c)
         e += 1
         c = read(line, Char)
-        Lexer.is_identifier_char(c) && push!(word, c)
+        Base.is_id_char(c) && push!(word, c)
     end
     for i = 1:2 # Delete junk at front
         !isempty(word) && word[1] in [' ','.','!'] && deleteat!(word, 1)


### PR DESCRIPTION
I started to have a look at forking JuliaParser to have it store state and line/column info at intermediate stages of parsing and think it can be done but for now we may as well strip these dependencies?

I've also fixed `get_word` to handle cases such as `321sin(x)`.