### PR TITLE
Disable terminal server

### DIFF
--- a/scripts/terminalserver/terminalserver.jl
+++ b/scripts/terminalserver/terminalserver.jl
@@ -11,6 +11,7 @@ else
 end
 
 @async begin
+    # TODO Make sure the socket gets closed before this process terminates
     server = listen(global_lock_socket_name)
     while true
         sock = accept(server)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -211,7 +211,8 @@ function startREPLCommand() {
 function startREPL() {
     if (REPLterminal==null) {
         let args = path.join(extensionPath, 'scripts', 'terminalserver', 'terminalserver.jl')
-        REPLterminal = vscode.window.createTerminal("julia", juliaExecutable, ['-q', '-i', args, process.pid.toString()]);
+        // REPLterminal = vscode.window.createTerminal("julia", juliaExecutable, ['-q', '-i', args, process.pid.toString()]);
+        REPLterminal = vscode.window.createTerminal("julia", juliaExecutable, ['-q', '-i']);
     }
 }
 


### PR DESCRIPTION
For the 0.5.0 release, just not run the terminal server socket, given that we don't use it in any case. This fixes #76.