### PR TITLE
Fix open package command

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
     },
     "dependencies": {
         "vscode-languageclient": "^2.2.1",
-        "child-process-promise": "^v2.2.0"
+        "child-process-promise": "^v2.2.0",
+        "async-file": "^v2.0.2"
     },
     "devDependencies": {
         "typescript": "^2.0.3",


### PR DESCRIPTION
@ZacLN  Can you try this? I hope this works on all systems now. I've removed the julia version selector, instead this should just show all the packages that are relevant for julia binary that is configured.