### PR TITLE
Disable autoClosingParis "" in string & comment

### DIFF
--- a/julia.configuration.json
+++ b/julia.configuration.json
@@ -16,8 +16,8 @@
         ["{", "}"],
         ["[", "]"],
         ["(", ")"],
-        ["\"", "\""],
-        ["`", "`"]
+        ["`", "`"],
+        { "open": "\"", "close": "\"", "notIn": ["string", "comment"] }
     ],
     // symbols that that can be used to surround a selection
     "surroundingPairs": [


### PR DESCRIPTION
It is a bit annoying it auto closes `"` at the end of a string.

I see the official language uses this trick

https://code.visualstudio.com/docs/extensionAPI/extension-points#_contributeslanguages

`{ "open": "'", "close": "'", "notIn": ["string", "comment"] },`