### PR TITLE
executeJuliaCodeInREPL ctrl+Enter -> alt+Enter

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
         ],
         "keybindings": [{
             "command": "language-julia.executeJuliaCodeInREPL",
-            "key": "ctrl+Enter",
+            "key": "alt+Enter",
             "when": "editorTextFocus"
         }],
         "configuration": {


### PR DESCRIPTION
``ctrl+Enter`` is a very useful key binding in vscode to go to a newline below current line. I suggest not override this command. It seems ``alt+Enter`` is available for our use.