### PR TITLE
make linter optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,10 @@
             {
                 "command": "language-julia.runTests",
                 "title": "julia: Run tests"
+            },
+            {
+                "command": "language-julia.toggleLinter",
+                "title": "julia: Toggle Linter"
             }
         ],
         "keybindings": [{
@@ -88,6 +92,11 @@
                     "type": ["string", "null"],
                     "default": null,
                     "description": "Points to the julia executable."
+                },
+                "julia.runlinter": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Option to automatically run the Linter on active files."
                 }
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,6 +50,9 @@ export function activate(context: vscode.ExtensionContext) {
     let disposable_runTests = vscode.commands.registerCommand('language-julia.runTests', runTests);
     context.subscriptions.push(disposable_runTests);
 
+    let disposable_toggleLinter = vscode.commands.registerCommand('language-julia.toggleLinter', toggleLinter);
+    context.subscriptions.push(disposable_toggleLinter);
+
     testStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
     testStatusBarItem.tooltip = 'Interrupt test run.';
     testStatusBarItem.text = '$(beaker) julia tests are running...';
@@ -147,7 +150,10 @@ async function startLanguageServer() {
 
     let clientOptions: LanguageClientOptions = {
         // Register the server for plain text documents
-        documentSelector: ['julia']
+        documentSelector: ['julia'],
+        synchronize: {
+            configurationSection: 'julia.runlinter'
+        }
     }
 
     // Create the language client and start the client.
@@ -334,4 +340,10 @@ function executeJuliaCodeInREPL() {
     // var failCount = 0;
 
     // client.on('error', onError);
+}
+
+
+export function toggleLinter() {
+    let cval = vscode.workspace.getConfiguration('julia').get('runlinter', false)
+    vscode.workspace.getConfiguration('julia').update('runlinter', !cval, true)
 }


### PR DESCRIPTION
Adds ability to turn linter on/off. Files must be saved to update (e.g. either add or remove linter messages)