### PR TITLE
Add weave command

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "onCommand:language-julia.startREPL",
         "onCommand:language-julia.executeJuliaCodeInREPL",
         "onCommand:language-julia.runTests",
+        "onCommand:language-julia.weave",
         "onLanguage:julia"
     ],
     "main": "./out/src/extension",
@@ -77,6 +78,10 @@
             {
                 "command": "language-julia.toggleLinter",
                 "title": "julia: Toggle Linter"
+            },
+            {
+                "command": "language-julia.weave",
+                "title": "julia: Weave document"
             }
         ],
         "keybindings": [{

--- a/package.json
+++ b/package.json
@@ -43,6 +43,16 @@
                     ".jl"
                 ],
                 "configuration": "./julia.configuration.json"
+            },
+            {
+                "id": "juliamarkdown",
+                "aliases": [
+                    "julia Markdown",
+                    "juliamarkdown"
+                ],
+                "extensions": [
+                    ".jmd"
+                ]
             }
         ],
         "grammars": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,16 +20,28 @@ let g_context: vscode.ExtensionContext = null;
 let testOutputChannel: vscode.OutputChannel = null;
 let testChildProcess: ChildProcess = null;
 let testStatusBarItem: vscode.StatusBarItem = null;
-let weaveProvider: vscode.TextDocumentContentProvider = null;
 let lastWeaveContent: string = null;
 let weaveOutputChannel: vscode.OutputChannel = null;
 let weaveChildProcess: ChildProcess = null;
 
 export class WeaveDocumentContentProvider implements vscode.TextDocumentContentProvider {
+    private _onDidChange = new vscode.EventEmitter<vscode.Uri>();
+
     public provideTextDocumentContent(uri: vscode.Uri): string {
         return lastWeaveContent;
     }
+
+    get onDidChange(): vscode.Event<vscode.Uri> {
+        return this._onDidChange.event;
+    }
+
+    public update() {
+        
+        this._onDidChange.fire(vscode.Uri.parse('jlweave://nothing.html'));
+    }
 }
+
+let weaveProvider: WeaveDocumentContentProvider = null;
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -269,6 +281,7 @@ async function weaveCommand() {
                 lastWeaveContent = await fs.readFile(output_filename, "utf-8")
 
                 let uri = vscode.Uri.parse('jlweave://nothing.html');
+                weaveProvider.update();
                 let success = await vscode.commands.executeCommand('vscode.previewHtml', uri, vscode.ViewColumn.One, "julia weave output");
             }
             else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -231,7 +231,7 @@ async function weaveCommand() {
     else if (vscode.window.activeTextEditor.document.isDirty || vscode.window.activeTextEditor.document.isUntitled) {
         vscode.window.showErrorMessage('Please safe the current file before you weave it.');
     }
-    else if (vscode.window.activeTextEditor.document.languageId!='julia') {
+    else if (vscode.window.activeTextEditor.document.languageId!='julia' && vscode.window.activeTextEditor.document.languageId!='juliamarkdown') {
         vscode.window.showErrorMessage('Only julia (.jl) files can be weaved.')
     }
     else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -229,10 +229,10 @@ async function weaveCommand() {
         vscode.window.showErrorMessage('Please open a document before you execute the weave command.');
     }
     else if (vscode.window.activeTextEditor.document.isDirty || vscode.window.activeTextEditor.document.isUntitled) {
-        vscode.window.showErrorMessage('Please safe the current file before you weave it.');
+        vscode.window.showErrorMessage('Please save the current file before you weave it.');
     }
     else if (vscode.window.activeTextEditor.document.languageId!='julia' && vscode.window.activeTextEditor.document.languageId!='juliamarkdown') {
-        vscode.window.showErrorMessage('Only julia (.jl) files can be weaved.')
+        vscode.window.showErrorMessage('Only julia (.jl or .jmd) files can be weaved.')
     }
     else {
         let parsed_filename = path.parse(vscode.window.activeTextEditor.document.fileName);


### PR DESCRIPTION
This adds a weave command for [Weave.jl](https://github.com/mpastell/Weave.jl).

~~Right now I only support script weave files. It would be nice to add support for jmd files down the road, but I think before we do that we would need to figure out things like syntax highlighting and how that integrates with our LS etc.~~

FYI @mpastell