### PR TITLE
Various weave features

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
         "onCommand:language-julia.startREPL",
         "onCommand:language-julia.executeJuliaCodeInREPL",
         "onCommand:language-julia.runTests",
-        "onCommand:language-julia.weave",
+        "onCommand:language-julia.weave-open-preview",
+        "onCommand:language-julia.weave-open-preview-side",
+        "onCommand:language-julia.weave-save",
         "onLanguage:julia"
     ],
     "main": "./out/src/extension",
@@ -90,8 +92,16 @@
                 "title": "julia: Toggle Linter"
             },
             {
-                "command": "language-julia.weave",
-                "title": "julia: Weave document"
+                "command": "language-julia.weave-open-preview",
+                "title": "julia Weave: Open Preview"
+            },
+            {
+                "command": "language-julia.weave-open-preview-side",
+                "title": "julia Weave: Open Preview to the Side"
+            },
+            {
+                "command": "language-julia.weave-save",
+                "title": "julia Weave: Save to file..."
             }
         ],
         "keybindings": [{
@@ -125,7 +135,8 @@
         "vscode-languageclient": "^2.2.1",
         "child-process-promise": "^v2.2.0",
         "async-file": "^v2.0.2",
-        "async-child-process": "^v1.1.1"
+        "async-child-process": "^v1.1.1",
+        "promised-temp": "^v0.1.0"
     },
     "devDependencies": {
         "typescript": "^2.0.3",

--- a/scripts/weave/preview.tpl
+++ b/scripts/weave/preview.tpl
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<HTML lang = "en">
+<HEAD>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+  {{#:title}}<title>{{:title}}</title>{{/:title}}
+  {{{ :header_script }}}
+
+  <script type="text/x-mathjax-config">
+    MathJax.Hub.Config({
+      tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
+    });
+  </script>
+
+  <script src='https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
+
+  <style type="text/css">
+  {{{ :themecss }}}
+  </style>
+
+  {{{ :highlightcss }}}
+
+</HEAD>
+  <BODY>
+    <div class ="container">
+      <div class = "row">
+        <div class = "col-md-12 twelve columns">
+
+          <div class="title">
+            {{#:title}}<h1 class="title">{{:title}}</h1>{{/:title}}
+            {{#:author}}<h5>{{{:author}}}</h5>{{/:author}}
+            {{#:date}}<h5>{{{:date}}}</h5>{{/:date}}
+          </div>
+
+          {{{ :body }}}
+
+
+          <HR/>
+          <div class="footer"><p>
+          Published using
+          <a href="http://github.com/mpastell/Weave.jl" target="_blank">Weave.jl</a>
+          {{:wversion}} on {{:wtime}}.
+          <p></div>
+
+
+        </div>
+      </div>
+    </div>
+  </BODY>
+</HTML>

--- a/scripts/weave/run_weave.jl
+++ b/scripts/weave/run_weave.jl
@@ -1,0 +1,28 @@
+stderr_copy = Base.STDERR
+
+rserr, wrerr = redirect_stderr()
+
+using Weave
+# For some reason this is needed on Windows, without it we see lots of errors
+info("Ignore")
+
+redirect_stderr(stderr_copy)
+close(rserr)
+close(wrerr)
+
+input_file = readline()
+input_file = chomp(input_file)
+
+output_file = readline()
+output_file = chomp(output_file)
+
+doctype = readline()
+doctype = chomp(doctype)
+
+if doctype=="PREVIEW"
+    template_path = joinpath(dirname(@__FILE__), "preview.tpl")
+
+    Weave.weave(input_file, out_path=output_file, template=template_path)
+else
+    Weave.weave(input_file, out_path=:doc, doctype=doctype)
+end


### PR DESCRIPTION
Lots of stuff here:

- At every weave, pre-start a julia process for the next weave. This speeds things up quit a bit.
- Have two weave preview commands, one for column one, one for side-by-side.
- Add a save to file command that shows all the supported output formats as an option and then saves the result to a file.
- Weave preview works without saving the source file and no longer generates any files in the workspace.
- Generally suppress some annoying console output messages about Weave overriding various methods.
- Use a template for the preview that doesn't show a link to the source file, and open the weave homepage in a different window.
- Drop support for script input files, so only .jmd files are supported going forward.

I think that pretty much covers what we need for now.

FYI @mpastell. Also, would be great if you could tag a new Weave release that has some of the additional fixes we added, so that this here works with the latest registered Weave version.