### PR TITLE
Always load packages from extension

### DIFF
--- a/scripts/languageserver/main.jl
+++ b/scripts/languageserver/main.jl
@@ -15,10 +15,8 @@ elseif Base.ARGS[2]=="--debug=yes"
     const global ls_debug_mode = true
 end
 
-if !ls_debug_mode
-    push!(LOAD_PATH, joinpath(dirname(@__FILE__),"packages"))
-    push!(LOAD_PATH, Base.ARGS[1])
-end
+push!(LOAD_PATH, joinpath(dirname(@__FILE__),"packages"))
+push!(LOAD_PATH, Base.ARGS[1])
 
 using Compat
 using JSON


### PR DESCRIPTION
This changes things so that the VS Code extension now always uses LanguageServer etc. from the submodule in the VS Code extension, and never from the global .julia folder. Now that we only have one copy of the packages in the VS Code extension (no longer two for each version of julia), this seems fairly simple. Essentially the workflow now is that if you want to change something in say LanguageServer, you just make the change in the submodule.