### PR TITLE
Update indentation rules

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -105,13 +105,10 @@ export function activate(context: vscode.ExtensionContext) {
         }
     })
     vscode.languages.setLanguageConfiguration('julia', {
-        onEnterRules: [
-            {
-                beforeText: /^\s*(?:abstract|type|bitstype|immutable|function|macro|for|if|elseif|else|while|try|with|finally|catch|except|async|let|do).*\s*$/,
-                action: { indentAction: vscode.IndentAction.Indent}
-            }
-        ]
-
+        indentationRules: {
+            increaseIndentPattern: /^(\s*|.*=\s*|.*@\w*\s*)[\w\s]*(if|while|for|function|macro|immutable|struct|type|let|quote|try|begin|.*\)\s*do|else|elseif|catch|finally)\b(?!.*\bend\b[^\]]*$).*$/,
+            decreaseIndentPattern: /^\s*(end|else|elseif|catch|finally)\b.*$/
+        }
     });
     startLanguageServer();
 }


### PR DESCRIPTION
This copies the indentation rule from [here](https://github.com/JuliaEditorSupport/atom-language-julia/blob/master/settings/language-julia.cson).

With current VS Code versions things should now unindent if you press Enter after the ``end``. Still not ideal, but I think we have to wait until Microsoft/vscode#2272 gets properly fixed for unindent when the word ``end`` is just typed.

This makes some progress on #37.