### PR TITLE
Parse options passed into the language server -- at least a little

### DIFF
--- a/scripts/languageserver/main.jl
+++ b/scripts/languageserver/main.jl
@@ -12,6 +12,8 @@ function handle_flags(arg)
             global ls_debug_mode = false
         elseif arg=="--debug=yes"
             global ls_debug_mode = true
+        else
+            error("Unexpected flag argument: $(arg)")
         end
         true
     else
@@ -23,7 +25,7 @@ if length(Base.ARGS)>=1
     if !handle_flags(Base.ARGS[1])
         user_pkg_dir = Base.ARGS[1]
     end
-    map(handle_flags, Base.ARGS[2:end])
+    all(handle_flags, Base.ARGS[2:end]) || error("NonFlag argument not in first position. Arguments: $(Base.ARGS)")
 end
 
 conn = STDOUT


### PR DESCRIPTION
This makes flags passed in be handled as flags; with defaults and error messages

And use the same defaults for Package Dir not provided as LanguageServer.jl does.

It could probably be done nicer with a command line argument parsing library, but that would add a dependency.