### PR TITLE
Add v0.6 keywords to syntax highlighting

### DIFF
--- a/syntaxes/julia.json
+++ b/syntaxes/julia.json
@@ -166,7 +166,7 @@
         "keyword": {
             "patterns": [
                 {
-                    "match": "\\b(?<![:_])(?:function|@generated|type|immutable|macro|quote|abstract|bitstype|typealias|module|baremodule|new)\\b",
+                    "match": "\\b(?<![:_])(?:function|@generated|type|immutable|macro|quote|abstract|bitstype|typealias|module|baremodule|new|struct|mutable struct|primitive type|abstract type|where)\\b",
                     "name": "keyword.other.julia"
                 },
                 {


### PR DESCRIPTION
Should the deprecated syntax be removed?

0.6:

- `typealias`
- `abstract`
- `bitstype`

1.0+:

- `type`
- `immutable`