### PR TITLE
WIP: status bar icon

### DIFF
--- a/scripts/languageserver/packages/CSTParser
+++ b/scripts/languageserver/packages/CSTParser
@@ -1,1 +1,1 @@
-/home/zac/github/CSTParser/
+

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -135,7 +135,7 @@ export function activate(context: vscode.ExtensionContext) {
     serverstatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
     
     serverstatus.show()
-    serverstatus.text = 'Julia-LS';
+    serverstatus.text = 'Julia: starting up';
     context.subscriptions.push(serverstatus);
 
     startREPLconnectionServer();
@@ -177,14 +177,8 @@ export function activate(context: vscode.ExtensionContext) {
         }
     });
     startLanguageServer();
-    
-    
-    languageClient.onNotification(serverBusyNotification, () => {
-        serverstatus.color.fontcolor('red')
-    })
-    languageClient.onNotification(serverReadyNotification, () => {
-        serverstatus.color.fontcolor('blue')
-    })
+
+
 }
 
 // this method is called when your extension is deactivated
@@ -276,6 +270,19 @@ async function startLanguageServer() {
         vscode.window.showErrorMessage('Could not start the julia language server. Make sure the configuration setting julia.executablePath points to the julia binary.');
         languageClient = null;
     }
+
+    languageClient.onReady().then(()=>{
+        languageClient.onNotification(serverBusyNotification, setStatusBusy)
+        languageClient.onNotification(serverReadyNotification, setStatusReady)
+    })
+}
+
+function setStatusBusy() {
+    serverstatus.text = 'Julia: busy'
+}
+
+function setStatusReady() {
+    serverstatus.text = 'Julia: ready'
 }
 
 // This method implements the language-julia.openPackageDirectory command


### PR DESCRIPTION
Adds a status bar item to indicate when the language server is busy.

@davidanthoff  I can't work out how to get the 6 lines following https://github.com/ZacLN/julia-vscode/blob/status-item/src/extension.ts#L182 this run only after the server has been started, any ideas?

Goes with [this](https://github.com/JuliaEditorSupport/LanguageServer.jl/pull/91) on the server side