### PR TITLE
Use VS Code task system

### DIFF
--- a/package.json
+++ b/package.json
@@ -265,7 +265,12 @@
                     "description": "Option to automatically run the Linter on active files."
                 }
             }
-        }
+        },
+        "taskDefinitions": [
+            {
+                "type": "julia"
+            }
+        ]
     },
     "scripts": {
         "vscode:prepublish": "tsc -p ./",

--- a/package.json
+++ b/package.json
@@ -268,7 +268,15 @@
         },
         "taskDefinitions": [
             {
-                "type": "julia"
+                "type": "julia",
+                "required": [
+                    "command"
+                ],
+                "properties": {
+                    "command": {
+                        "type": "string"
+                    }
+                }
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,10 @@
         "onCommand:language-julia.lint-package",
         "onCommand:language-julia.show-plotpane",
         "onLanguage:julia",
-        "onLanguage:juliamarkdown"
+        "onLanguage:juliamarkdown",
+        "workspaceContains:deps/build.jl",
+        "workspaceContains:test/runtests.jl",
+        "workspaceContains:benchmark/benchmarks.jl"
     ],
     "main": "./out/src/extension",
     "contributes": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
         "onCommand:language-julia.openPackageDirectory",
         "onCommand:language-julia.startREPL",
         "onCommand:language-julia.executeJuliaCodeInREPL",
-        "onCommand:language-julia.runTests",
         "onCommand:language-julia.weave-open-preview",
         "onCommand:language-julia.weave-open-preview-side",
         "onCommand:language-julia.weave-save",
@@ -90,10 +89,6 @@
             {
                 "command": "language-julia.executeJuliaCodeInREPL",
                 "title": "Julia: Execute Code"
-            },
-            {
-                "command": "language-julia.runTests",
-                "title": "Julia: Run tests"
             },
             {
                 "command": "language-julia.toggleLinter",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "version": "0.7.0-dev",
     "publisher": "julialang",
     "engines": {
-        "vscode": "^1.7.0"
+        "vscode": "^1.14.0"
     },
     "license": "SEE LICENSE IN LICENSE",
     "bugs": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -690,6 +690,14 @@ async function getJuliaTasks(): Promise<vscode.Task[]> {
             result.push(buildTask);
         }
 
+        if (await fs.exists(path.join(workspaceRoot, 'benchmark', 'benchmarks.jl'))) {
+            let splitted_path = vscode.workspace.rootPath.split(path.sep);
+            let package_name = splitted_path[splitted_path.length-1];
+            let benchmarkTask = new vscode.Task({ type: 'julia', command: 'benchmark'}, `Run benchmark`, 'julia', new vscode.ProcessExecution(juliaExecutable, ['--color=yes', '-e', 'using PkgBenchmark; benchmarkpkg(Base.ARGS[1], promptsave=false, promptoverwrite=false)', package_name]), "");
+            benchmarkTask.presentationOptions = { echo: false };
+            result.push(benchmarkTask);
+        }
+
 		return Promise.resolve(result);
 	} catch (e) {
 		return Promise.resolve(emptyTasks);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -675,14 +675,16 @@ async function getJuliaTasks(): Promise<vscode.Task[]> {
         const result: vscode.Task[] = [];
 
         if (await fs.exists(path.join(workspaceRoot, 'test', 'runtests.jl'))) {
-            let testTask = new vscode.Task({ type: 'julia', command: 'test' }, `Run tests`, 'julia', new vscode.ProcessExecution(juliaExecutable, ['--color=yes', '-e', 'Pkg.test(Base.ARGS[1])', vscode.workspace.rootPath]), []);
+            let testTask = new vscode.Task({ type: 'julia', command: 'test' }, `Run tests`, 'julia', new vscode.ProcessExecution(juliaExecutable, ['--color=yes', '-e', 'Pkg.test(Base.ARGS[1])', vscode.workspace.rootPath]), "");
             testTask.group = vscode.TaskGroup.Test;
             testTask.presentationOptions = { echo: false };
             result.push(testTask);
         }
 
         if (await fs.exists(path.join(workspaceRoot, 'deps', 'build.jl'))) {
-            let buildTask = new vscode.Task({ type: 'julia', command: 'build' }, `Run build`, 'julia', new vscode.ProcessExecution(juliaExecutable, ['--color=yes', '-e', 'Pkg.build(Base.ARGS[1])', vscode.workspace.rootPath]), []);
+            let splitted_path = vscode.workspace.rootPath.split(path.sep);
+            let package_name = splitted_path[splitted_path.length-1];
+            let buildTask = new vscode.Task({ type: 'julia', command: 'build'}, `Run build`, 'julia', new vscode.ProcessExecution(juliaExecutable, ['--color=yes', '-e', 'Pkg.build(Base.ARGS[1])', package_name]), "");
             buildTask.group = vscode.TaskGroup.Build;
             buildTask.presentationOptions = { echo: false };
             result.push(buildTask);


### PR DESCRIPTION
This uses the VS Code task system for running a) tests, b) build.jl and c) benchmarks.

Also removes the previous manual test runner stuff.