### PR TITLE
add reload-modules command

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "onCommand:language-julia.weave-save",
         "onCommand:language-julia.lint-package",
         "onCommand:language-julia.show-plotpane",
+        "onCommand:language-julia.reload-modules",
         "onLanguage:julia",
         "onLanguage:juliamarkdown"
     ],

--- a/package.json
+++ b/package.json
@@ -116,6 +116,10 @@
                 "title": "Julia: Lint Package"
             },
             {
+                "command": "language-julia.reload-modules",
+                "title": "Julia: Reload imported modules"
+            },
+            {
                 "command": "language-julia.show-plotpane",
                 "title": "Julia: Show plot pane"
             },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,6 +113,9 @@ export function activate(context: vscode.ExtensionContext) {
     let lintpkg = vscode.commands.registerCommand('language-julia.lint-package', lintPackage);
     context.subscriptions.push(lintpkg);
 
+    let reloadmodules = vscode.commands.registerCommand('language-julia.reload-modules', reloadModules);
+    context.subscriptions.push(lintpkg);
+
     let showplotpane = vscode.commands.registerCommand('language-julia.show-plotpane', showPlotPane);
     context.subscriptions.push(showplotpane);
 
@@ -664,6 +667,21 @@ export function lintPackage() {
         }
     }
 }
+
+export function reloadModules() {
+    try {
+        languageClient.sendRequest("julia/reload-modules");
+    }
+    catch(ex) {
+        if(ex.message=="Language client is not ready yet") {
+            vscode.window.showErrorMessage('Error: Language server is not yet running.');
+        }
+        else {
+            throw ex;
+        }
+    }
+}
+
 
 function showPlotPane() {
     let uri = vscode.Uri.parse('jlplotpane://nothing.html');


### PR DESCRIPTION
Add menu option to force reload of (edited) modules imported in user code. 

This may allow slightly faster editting of LanguageServer as long as the LanguageServerInstance struct isn't changed? 

Goes w/ https://github.com/JuliaEditorSupport/LanguageServer.jl/pull/124