### PR TITLE
add toggle lint menu option

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,9 +154,23 @@
                     "light": "./media/delete.svg",
                     "dark": "./media/delete-inverse.svg"
                 }
+            },
+            {
+                "command": "language-julia.toggle-file-lint",
+                "title": "Julia: Toggle file linting"
             }
         ],
         "menus": {
+            "explorer/context": [
+                {
+                    "when": "resourceLangId == julia",
+                    "command": "language-julia.toggle-file-lint"
+                },
+                {
+                    "when": "explorerResourceIsFolder",
+                    "command": "language-julia.toggle-file-lint"
+                }
+            ],
             "editor/title": [
                 {
                     "when": "resourceScheme == jlplotpane",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -131,6 +131,8 @@ export function activate(context: vscode.ExtensionContext) {
 
     let plotpanedel = vscode.commands.registerCommand('language-julia.plotpane-delete', plotPaneDel);
     context.subscriptions.push(plotpanedel);    
+
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.toggle-file-lint', ignoreFile));   
     
     serverstatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);   
     serverstatus.show()
@@ -726,4 +728,10 @@ async function getJuliaTasks(): Promise<vscode.Task[]> {
 	} catch (e) {
 		return Promise.resolve(emptyTasks);
 	}
+}
+
+function ignoreFile(fileURI) {
+    if (fileURI) {
+        languageClient.sendRequest("julia/toggleFileLint" , fileURI.toString());
+    }
 }


### PR DESCRIPTION
Adds toggle lint for files/folders to the explorer menu. I'm not sure how we want to enable this persistantly, could we possibly use .vscodeignore ?