### PR TITLE
split weave/repl functions into seperate files

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,10 @@
                 "title": "Julia: Execute Code"
             },
             {
+                "command": "language-julia.executeJuliaFileInREPL",
+                "title": "Julia: Execute File"
+            },
+            {
                 "command": "language-julia.toggleLinter",
                 "title": "Julia: Toggle Linter"
             },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,157 +12,85 @@ var tempfs = require('promised-temp').track();
 import { spawn, ChildProcess } from 'child_process';
 import { LanguageClient, LanguageClientOptions, SettingMonitor, ServerOptions, TransportKind, StreamInfo } from 'vscode-languageclient';
 import * as rpc from 'vscode-jsonrpc';
+import { REPLHandler, PlotPaneDocumentContentProvider } from './repl'
+import { WeaveDocumentContentProvider } from './weave'
 
 let juliaExecutable = null;
 let juliaPackagePath: string = null;
 let languageClient: LanguageClient = null;
-let REPLterminal: vscode.Terminal = null;
 let extensionPath: string = null;
 let g_context: vscode.ExtensionContext = null;
-let lastWeaveContent: string = null;
-let weaveOutputChannel: vscode.OutputChannel = null;
-let weaveChildProcess: ChildProcess = null;
-let weaveNextChildProcess: ChildProcess = null;
-let plots: Array<string> = new Array<string>();
-let currentPlotIndex: number = 0;
 let serverstatus: vscode.StatusBarItem = null;
 let serverBusyNotification = new rpc.NotificationType<string, void>('window/setStatusBusy');
 let serverReadyNotification = new rpc.NotificationType<string, void>('window/setStatusReady');
 let taskProvider: vscode.Disposable | undefined;
 
-export class WeaveDocumentContentProvider implements vscode.TextDocumentContentProvider {
-    private _onDidChange = new vscode.EventEmitter<vscode.Uri>();
-
-    public provideTextDocumentContent(uri: vscode.Uri): string {
-        return lastWeaveContent;
-    }
-
-    get onDidChange(): vscode.Event<vscode.Uri> {
-        return this._onDidChange.event;
-    }
-
-    public update() {
-        
-        this._onDidChange.fire(vscode.Uri.parse('jlweave://nothing.html'));
-    }
-}
-
-let weaveProvider: WeaveDocumentContentProvider = null;
-
-export class PlotPaneDocumentContentProvider implements vscode.TextDocumentContentProvider {
-    private _onDidChange = new vscode.EventEmitter<vscode.Uri>();
-
-    public provideTextDocumentContent(uri: vscode.Uri): string {
-        if(plots.length==0) {
-            return '<html></html>';
-        }
-        else {
-            return plots[currentPlotIndex];
-        }
-    }
-
-    get onDidChange(): vscode.Event<vscode.Uri> {
-        return this._onDidChange.event;
-    }
-
-    public update() {
-        
-        this._onDidChange.fire(vscode.Uri.parse('jlplotpane://nothing.html'));
-    }
-}
-
-let plotPaneProvider: PlotPaneDocumentContentProvider = null;
-
-// this method is called when your extension is activated
-// your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
     g_context = context;
     extensionPath = context.extensionPath;
-    // Use the console to output diagnostic information (console.log) and errors (console.error)
-    // This line of code will only be executed once when your extension is activated
     console.log('Activating extension language-julia');
 
     loadConfiguration();
+    
+    // REPL
+    // const replTree = new REPLTree(context);
+    let repl = new REPLHandler(extensionPath, juliaExecutable)
+    context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider('jlplotpane', repl.plotPaneProvider));
+    vscode.window.registerTreeDataProvider('REPLVariables', repl);
+    
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.startREPL', () => {repl.startREPL()}));
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.executeJuliaCodeInREPL', () => {repl.executeCode()}));
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.change-repl-module', () => repl.sendMessage('repl/getAvailableModules')));
 
-    let disposable_configchange = vscode.workspace.onDidChangeConfiguration(configChanged);
-    context.subscriptions.push(disposable_configchange);
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.show-plotpane', repl.plotPaneProvider.showPlotPane));
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.plotpane-previous', repl.plotPaneProvider.plotPanePrev));
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.plotpane-next', repl.plotPaneProvider.plotPaneNext));
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.plotpane-first', repl.plotPaneProvider.plotPaneFirst));
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.plotpane-last', repl.plotPaneProvider.plotPaneLast));
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.plotpane-delete', repl.plotPaneProvider.plotPaneDel));
 
-    // The command has been defined in the package.json file
-    // Now provide the implementation of the command with  registerCommand
-    // The commandId parameter must match the command field in package.json
-    let disposable_OpenPkgCommand = vscode.commands.registerCommand('language-julia.openPackageDirectory', openPackageDirectoryCommand);
-    context.subscriptions.push(disposable_OpenPkgCommand);
 
-    let disposable_StartREPLCommand = vscode.commands.registerCommand('language-julia.startREPL', startREPLCommand);
-    context.subscriptions.push(disposable_StartREPLCommand);
-
-    let weave_open_preview = vscode.commands.registerCommand('language-julia.weave-open-preview', weave_open_preview_Command);
-    context.subscriptions.push(weave_open_preview);
-
-    let weave_open_preview_side = vscode.commands.registerCommand('language-julia.weave-open-preview-side', weave_open_preview_side_Command);
-    context.subscriptions.push(weave_open_preview_side);
-
-    let weave_save = vscode.commands.registerCommand('language-julia.weave-save', weave_save_Command);
-    context.subscriptions.push(weave_save);
-
-    let applytextedit = vscode.commands.registerCommand('language-julia.applytextedit', applyTextEdit);
-    context.subscriptions.push(applytextedit);
-
-    let lintpkg = vscode.commands.registerCommand('language-julia.lint-package', lintPackage);
-    context.subscriptions.push(lintpkg);
-
-    let reloadmodules = vscode.commands.registerCommand('language-julia.reload-modules', reloadModules);
-    context.subscriptions.push(lintpkg);
-
-    let showplotpane = vscode.commands.registerCommand('language-julia.show-plotpane', showPlotPane);
-    context.subscriptions.push(showplotpane);
-
-    let plotpaneprev = vscode.commands.registerCommand('language-julia.plotpane-previous', plotPanePrev);
-    context.subscriptions.push(plotpaneprev);
-
-    let plotpanenext = vscode.commands.registerCommand('language-julia.plotpane-next', plotPaneNext);
-    context.subscriptions.push(plotpanenext);
-
-    let plotpanefirst = vscode.commands.registerCommand('language-julia.plotpane-first', plotPaneFirst);
-    context.subscriptions.push(plotpanefirst);
-
-    let plotpanelast = vscode.commands.registerCommand('language-julia.plotpane-last', plotPaneLast);
-    context.subscriptions.push(plotpanelast);
-
-    let plotpanedel = vscode.commands.registerCommand('language-julia.plotpane-delete', plotPaneDel);
-    context.subscriptions.push(plotpanedel);
-
-    // context.subscriptions.push(vscode.commands.registerCommand('language-julia.change-repl-module', changeREPLModule));
-
-    context.subscriptions.push(vscode.commands.registerCommand('language-julia.change-repl-module', () => sendMessageToREPL('repl/getAvailableModules')));
-
-    context.subscriptions.push(vscode.commands.registerCommand('language-julia.toggle-log', toggleServerLogs));
-
+    // Status bar
     serverstatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);   
     serverstatus.show()
     serverstatus.text = 'Julia: starting up';
     context.subscriptions.push(serverstatus);
 
-    startREPLconnectionServer();
-    startREPLConn();
 
-    weaveProvider = new WeaveDocumentContentProvider();
-    let disposable_weaveProvider = vscode.workspace.registerTextDocumentContentProvider('jlweave', weaveProvider);
-    context.subscriptions.push(disposable_weaveProvider);
+    // Weave
+    let weaveProvider = new WeaveDocumentContentProvider(extensionPath, juliaExecutable);
+    context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider('jlweave', weaveProvider));
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.weave-open-preview', ()=>{weaveProvider.open_preview()}));
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.weave-open-preview-side', ()=>{weaveProvider.open_preview_side}));
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.weave-save', ()=>{weaveProvider.save}));
 
-    plotPaneProvider = new PlotPaneDocumentContentProvider();
-    let disposable_plotPaneProvider = vscode.workspace.registerTextDocumentContentProvider('jlplotpane', plotPaneProvider);
-    context.subscriptions.push(disposable_plotPaneProvider);
 
-    let disposable_executeJuliaCodeInREPL = vscode.commands.registerCommand('language-julia.executeJuliaCodeInREPL', executeJuliaCodeInREPL);
-    context.subscriptions.push(disposable_executeJuliaCodeInREPL);
+    // Misc. commands
+    context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(configChanged));
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.openPackageDirectory', openPackageDirectoryCommand));
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.applytextedit', applyTextEdit));
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.lint-package', lintPackage));
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.toggleLinter', toggleLinter));
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.reload-modules', reloadModules));
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.toggle-log', toggleServerLogs));
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.toggle-file-lint', (arg) => {
+        try {
+            languageClient.sendRequest("julia/toggleFileLint", arg);
+        }
+        catch(ex) {5
+            if(ex.message=="Language client is not ready yet") {
+                vscode.window.showErrorMessage('Error: server is not running.');
+            }
+            else {
+                throw ex;
+            }
+        }
 
-    let disposable_toggleLinter = vscode.commands.registerCommand('language-julia.toggleLinter', toggleLinter);
-    context.subscriptions.push(disposable_toggleLinter);
+    }));
 
     vscode.window.onDidCloseTerminal(terminal=>{
-        if (terminal==REPLterminal) {
-            REPLterminal = null;
+        if (terminal==repl.terminal) {
+            repl.terminal = null;
         }
     })
     vscode.languages.setLanguageConfiguration('julia', {
@@ -252,10 +180,9 @@ async function startLanguageServer() {
     };
 
     let clientOptions: LanguageClientOptions = {
-        // Register the server for plain text documents
         documentSelector: ['julia', 'juliamarkdown'],
         synchronize: {
-            configurationSection: 'julia.runlinter',
+            configurationSection: ['julia.runlinter', 'julia.lintIgnoreList'],
             fileEvents: vscode.workspace.createFileSystemWatcher('**/*.jl')
         }
     }
@@ -273,17 +200,9 @@ async function startLanguageServer() {
         languageClient = null;
     }
     languageClient.onReady().then(()=>{
-        languageClient.onNotification(serverBusyNotification, setStatusBusy)
-        languageClient.onNotification(serverReadyNotification, setStatusReady)
+        languageClient.onNotification(serverBusyNotification, ()=>{serverstatus.text = 'Julia: busy'})
+        languageClient.onNotification(serverReadyNotification, ()=>{serverstatus.text = 'Julia: ready'})
     })
-}
-
-function setStatusBusy() {
-    serverstatus.text = 'Julia: busy'
-}
-
-function setStatusReady() {
-    serverstatus.text = 'Julia: ready'
 }
 
 // This method implements the language-julia.openPackageDirectory command
@@ -321,285 +240,6 @@ async function openPackageDirectoryCommand() {
         vscode.window.showInformationMessage('Error: Could not read package directory.');
     }
 }
-
-async function weave_core(column, selected_format:string=undefined) {
-    let parsed_filename = path.parse(vscode.window.activeTextEditor.document.fileName);
-
-    let source_filename: string;
-    let output_filename: string;
-    if (selected_format===undefined) {
-        let temporary_dirname = await tempfs.mkdir("julia-vscode-weave");
-
-        source_filename = path.join(temporary_dirname, 'source-file.jmd')
-
-        await fs.writeFile(source_filename, vscode.window.activeTextEditor.document.getText(), 'utf8');
-    
-        output_filename = path.join(temporary_dirname, 'output-file.html');
-    }
-    else {
-        source_filename = vscode.window.activeTextEditor.document.fileName;
-        output_filename = '';
-    }
-
-    if (weaveOutputChannel == null) {
-        weaveOutputChannel = vscode.window.createOutputChannel("julia Weave");
-    }
-    weaveOutputChannel.clear();
-    weaveOutputChannel.show(true);
-
-    if (weaveChildProcess != null) {
-        try {
-            await kill(weaveChildProcess);
-        }
-        catch (e) {
-        }
-    }
-
-    if (weaveNextChildProcess == null) {
-        weaveNextChildProcess = spawn(juliaExecutable, [path.join(extensionPath, 'scripts', 'weave', 'run_weave.jl')]);
-    }
-    weaveChildProcess = weaveNextChildProcess;
-
-    weaveChildProcess.stdin.write(source_filename + '\n');
-    weaveChildProcess.stdin.write(output_filename + '\n');
-    if (selected_format===undefined) {
-        weaveChildProcess.stdin.write('PREVIEW\n');
-    }
-    else {
-        weaveChildProcess.stdin.write(selected_format + '\n');
-    }
-
-    weaveNextChildProcess = spawn(juliaExecutable, [path.join(extensionPath, 'scripts', 'weave', 'run_weave.jl')]);
-
-    weaveChildProcess.stdout.on('data', function (data) {
-        weaveOutputChannel.append(String(data));
-    });
-    weaveChildProcess.stderr.on('data', function (data) {
-        weaveOutputChannel.append(String(data));
-    });
-    weaveChildProcess.on('close', async function (code) {
-        weaveChildProcess = null;
-
-        if (code == 0) {
-            weaveOutputChannel.hide();
-
-            if (selected_format===undefined) {
-                lastWeaveContent = await fs.readFile(output_filename, "utf8")
-
-                let uri = vscode.Uri.parse('jlweave://nothing.html');
-                weaveProvider.update();
-                let success = await vscode.commands.executeCommand('vscode.previewHtml', uri, column, "julia Weave Preview");
-            }
-        }
-        else {
-            vscode.window.showErrorMessage("Error during weaving.");
-        }
-
-    });
-}
-
-async function weave_open_preview_Command() {
-    if (vscode.window.activeTextEditor === undefined) {
-        vscode.window.showErrorMessage('Please open a document before you execute the weave command.');
-    }
-    else if (vscode.window.activeTextEditor.document.languageId!='juliamarkdown') {
-        vscode.window.showErrorMessage('Only julia Markdown (.jmd) files can be weaved.');
-    }
-    else {
-        weave_core(vscode.ViewColumn.One);
-    }
-}
-
-async function weave_open_preview_side_Command() {
-    if (vscode.window.activeTextEditor === undefined) {
-        vscode.window.showErrorMessage('Please open a document before you execute the weave command.');
-    }
-    else if (vscode.window.activeTextEditor.document.languageId!='juliamarkdown') {
-        vscode.window.showErrorMessage('Only julia Markdown (.jmd) files can be weaved.');
-    }
-    else {
-        weave_core(vscode.ViewColumn.Two);
-    }
-}
-
-async function weave_save_Command() {
-    if (vscode.window.activeTextEditor === undefined) {
-        vscode.window.showErrorMessage('Please open a document before you execute the weave command.');
-    }
-    else if (vscode.window.activeTextEditor.document.languageId!='juliamarkdown') {
-        vscode.window.showErrorMessage('Only julia Markdown (.jmd) files can be weaved.');
-    }
-    else if (vscode.window.activeTextEditor.document.isDirty || vscode.window.activeTextEditor.document.isUntitled) {
-        vscode.window.showErrorMessage('Please save the file before weaving.');
-    }
-    else {
-        let formats = ['github: Github markdown',
-            'md2tex: Julia markdown to latex',
-            'pandoc2html: Markdown to HTML (requires Pandoc)',
-            'pandoc: Pandoc markdown',
-            'pandoc2pdf: Pandoc markdown',
-            'tex: Latex with custom code environments',
-            'texminted: Latex using minted for highlighting',
-            'md2html: Julia markdown to html',
-            'rst: reStructuredText and Sphinx',
-            'multimarkdown: MultiMarkdown',
-            'md2pdf: Julia markdown to latex',
-            'asciidoc: AsciiDoc'];
-        let result_format = await vscode.window.showQuickPick(formats, {placeHolder: 'Select output format'});
-        if (result_format!=undefined) {
-            let index = result_format.indexOf(':');
-            let selected_format = result_format.substring(0,index);
-            weave_core(vscode.ViewColumn.One, selected_format);
-        }
-    }
-}
-
-function startREPLconnectionServer() {
-    let PIPE_PATH = generatePipeName(process.pid.toString(), 'vscode-language-julia-terminal');
-
-    var server = net.createServer(function(stream) {
-        let accumulatingBuffer = new Buffer(0);
-
-        stream.on('data', function(c) {
-            accumulatingBuffer = Buffer.concat([accumulatingBuffer, Buffer.from(c)]);
-            let s = accumulatingBuffer.toString();
-            let index_of_sep_1 = s.indexOf(":");
-            let index_of_sep_2 = s.indexOf(";");
-
-            if(index_of_sep_2>-1) {
-                let mime_type = s.substring(0,index_of_sep_1);
-                let msg_len_as_string = s.substring(index_of_sep_1+1,index_of_sep_2);
-                let msg_len = parseInt(msg_len_as_string);
-                if(accumulatingBuffer.length>=mime_type.length+msg_len_as_string.length+2+msg_len) {
-                    let actual_image = s.substring(index_of_sep_2+1);
-                    if(accumulatingBuffer.length > mime_type.length+msg_len_as_string.length+2+msg_len) {
-                        accumulatingBuffer = Buffer.from(accumulatingBuffer.slice(mime_type.length+msg_len_as_string.length+2+msg_len + 1));
-                    }
-                    else {
-                        accumulatingBuffer = new Buffer(0);
-                    }
-
-                    if(mime_type=='image/svg+xml') {
-                        currentPlotIndex = plots.push(actual_image)-1;
-                    }
-                    else if(mime_type=='image/png') {
-                        let plotPaneContent = '<html><img src="data:image/png;base64,' + actual_image + '" /></html>';
-                        currentPlotIndex = plots.push(plotPaneContent)-1;
-                    }
-                    else {
-                        throw new Error();
-                    }
-                    
-
-                    let uri = vscode.Uri.parse('jlplotpane://nothing.html');
-                    plotPaneProvider.update();
-                    vscode.commands.executeCommand('vscode.previewHtml', uri, undefined, "julia Plot Pane");
-                }
-            }            
-        });
-    });
-
-    server.on('close',function(){
-        console.log('Server: on close');
-    })
-
-    server.listen(PIPE_PATH,function(){
-        console.log('Server: on listening');
-    })
-}
-
-function startREPLCommand() {
-    startREPL();
-    REPLterminal.show();
-}
-
-function startREPL() {
-    if (REPLterminal==null) {
-        let args = path.join(extensionPath, 'scripts', 'terminalserver', 'terminalserver.jl')
-        REPLterminal = vscode.window.createTerminal("julia", juliaExecutable, ['-q', '-i', args, process.pid.toString()]);
-    }
-}
-
-function generatePipeName(pid: string, name:string) {
-    if (process.platform === 'win32') {
-        return '\\\\.\\pipe\\' + name + '-' + pid;
-    }
-    else {
-        return path.join(os.tmpdir(), name + '-' + pid);
-    }
- }
-
-function executeJuliaCodeInREPL() {
-    var editor = vscode.window.activeTextEditor;
-    if(!editor) {
-        return;
-    }
- 
-    var selection = editor.selection;
- 
-    var text = selection.isEmpty ? editor.document.lineAt(selection.start.line).text : editor.document.getText(selection);
- 
-     // If no text was selected, try to move the cursor to the end of the next line
-    if (selection.isEmpty) {
-        for (var line = selection.start.line+1; line < editor.document.lineCount; line++) {
-            if (!editor.document.lineAt(line).isEmptyOrWhitespace) {
-                var newPos = selection.active.with(line, editor.document.lineAt(line).range.end.character);
-                var newSel = new vscode.Selection(newPos, newPos);
-                editor.selection = newSel;
-                break;
-            }
-        }
-    }
-
-    // This is the version that sends code to the REPL directly
-    var lines = text.split(/\r?\n/);
-    lines = lines.filter(line=>line!='');
-    text = lines.join('\n');
-
-    if(!text.endsWith("\n")) {
-        text = text + '\n';
-    }
-
-    startREPL();
-    REPLterminal.show(true);
-
-    REPLterminal.sendText(text, false);
-
-    // This is the version that has the julia process listen on a socket for code to be executed.
-    // This is disabled for now, until we figure out how to hide the julia prompt.
-    
-    // var namedPipe = generatePipeName(process.pid.toString());
-
-    // var onConnect = () => {
-    //     var msg = {
-    //         "command": "run",
-    //         "body": text
-    //     };
-    //     client.write("Command: run\n");
-    //     client.write(`Content-Length: ${text.length}\n`);
-    //     client.write(`\n`);
-    //     client.write(text);
-    // };
-
-    // var onError = (err) => {
-    //     failCount += 1;
-    //     if(failCount > 50) {
-    //         vscode.window.showInformationMessage('Could not execute code.');
-    //     }
-    //     else {
-    //         setTimeout(() => {
-    //             client = net.connect(namedPipe, onConnect);
-    //             client.on('error', onError);
-    //         },100);
-    //     }
-    // };
-
-    // var client = net.connect(namedPipe, onConnect);
-    // var failCount = 0;
-
-    // client.on('error', onError);
-}
-
 
 export function toggleLinter() {
     let cval = vscode.workspace.getConfiguration('julia').get('runlinter', false)
@@ -642,60 +282,16 @@ export function reloadModules() {
     }
 }
 
-
-function showPlotPane() {
-    let uri = vscode.Uri.parse('jlplotpane://nothing.html');
-    vscode.commands.executeCommand('vscode.previewHtml', uri, undefined, "julia Plot Pane");
-}
-
-function plotPanePrev() {
-    if(currentPlotIndex>0) {
-        currentPlotIndex = currentPlotIndex - 1;
-        plotPaneProvider.update();
-    }
-}
-
-function plotPaneNext() {
-    if(currentPlotIndex<plots.length-1) {
-        currentPlotIndex = currentPlotIndex + 1;
-        plotPaneProvider.update();
-    }
-}
-
-function plotPaneFirst() {
-    if(plots.length>0) {
-        currentPlotIndex = 0;
-        plotPaneProvider.update();
-    }
-}
-
-function plotPaneLast() {
-    if(plots.length>0) {
-        currentPlotIndex = plots.length - 1;
-        plotPaneProvider.update();
-    }
-}
-
-function plotPaneDel() {
-    if(plots.length>0) {
-        plots.splice(currentPlotIndex,1);
-        if(currentPlotIndex>plots.length-1) {
-            currentPlotIndex = plots.length - 1;
-        }
-        plotPaneProvider.update();
-    }
-}
-
 async function getJuliaTasks(): Promise<vscode.Task[]> {
-	let workspaceRoot = vscode.workspace.rootPath;
+    let workspaceRoot = vscode.workspace.rootPath;
 
-	let emptyTasks: vscode.Task[] = [];
+    let emptyTasks: vscode.Task[] = [];
 
-	if (!workspaceRoot) {
-		return emptyTasks;
-	}
+    if (!workspaceRoot) {
+        return emptyTasks;
+    }
 
-	try {
+    try {
         const result: vscode.Task[] = [];
 
         if (await fs.exists(path.join(workspaceRoot, 'test', 'runtests.jl'))) {
@@ -729,44 +325,10 @@ async function getJuliaTasks(): Promise<vscode.Task[]> {
             result.push(buildTask);
         }
 
-		return Promise.resolve(result);
-	} catch (e) {
-		return Promise.resolve(emptyTasks);
-	}
-}
-
-function sendMessageToREPL(msg: string) {
-    let sock = generatePipeName(process.pid.toString(), 'vscode-language-julia-torepl')
-
-    let conn = net.connect(sock)
-
-    conn.write(msg + "\n")
-    conn.on('error', () => {vscode.window.showErrorMessage("REPL open")})
-}
-
-function startREPLConn() {
-    let PIPE_PATH = generatePipeName(process.pid.toString(), 'vscode-language-julia-fromrepl');
-
-    var server = net.createServer(function(stream) {
-        let accumulatingBuffer = new Buffer(0);
-
-        stream.on('data', async function(c) {
-            accumulatingBuffer = Buffer.concat([accumulatingBuffer, Buffer.from(c)]);
-            let availableMods = accumulatingBuffer.toString().split(",")
-            let result = await vscode.window.showQuickPick(availableMods, {placeHolder: 'Switch to Module...'})
-            if (result!=undefined) {
-                sendMessageToREPL('repl/changeModule: ' + result)
-            }
-        });
-    });
-
-    server.on('close',function(){
-        console.log('Server: on close');
-    })
-
-    server.listen(PIPE_PATH, function(){
-        console.log('Server: on listening');
-    })
+        return Promise.resolve(result);
+    } catch (e) {
+        return Promise.resolve(emptyTasks);
+    }
 }
 
 export function toggleServerLogs() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,6 +40,7 @@ export function activate(context: vscode.ExtensionContext) {
     
     context.subscriptions.push(vscode.commands.registerCommand('language-julia.startREPL', () => {repl.startREPL()}));
     context.subscriptions.push(vscode.commands.registerCommand('language-julia.executeJuliaCodeInREPL', () => {repl.executeCode()}));
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.executeJuliaFileInREPL', () => {repl.executeFile()}));
     context.subscriptions.push(vscode.commands.registerCommand('language-julia.change-repl-module', () => repl.sendMessage('repl/getAvailableModules')));
 
     context.subscriptions.push(vscode.commands.registerCommand('language-julia.show-plotpane', repl.plotPaneProvider.showPlotPane));

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -253,6 +253,17 @@ export class REPLHandler implements vscode.TreeDataProvider<string> {
         this.terminal.sendText(text, false);
     }
 
+    public executeFile() {
+        var editor = vscode.window.activeTextEditor;
+        if(!editor) {
+            return;
+        }
+        let text = editor.document.getText()
+        this.startREPL();
+        this.terminal.show(true);
+        this.terminal.sendText(text, false);
+    }
+
     public sendMessage(msg: string) {
         this.startREPL()
         let sock = generatePipeName(process.pid.toString(), 'vscode-language-julia-torepl')

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -1,0 +1,263 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as net from 'net';
+import * as os from 'os';
+
+export class PlotPaneDocumentContentProvider implements vscode.TextDocumentContentProvider {
+    private _onDidChange = new vscode.EventEmitter<vscode.Uri>();
+    public plots: Array<string> = new Array<string>();
+    public currentPlotIndex: number = 0;
+
+    public provideTextDocumentContent(uri: vscode.Uri): string {
+        if(this.plots.length==0) {
+            return '<html></html>';
+        }
+        else {
+            return this.plots[this.currentPlotIndex];
+        }
+    }
+
+    get onDidChange(): vscode.Event<vscode.Uri> {
+        return this._onDidChange.event;
+    }
+
+    public update() {
+        this._onDidChange.fire(vscode.Uri.parse('jlplotpane://nothing.html'));
+    }
+
+    public showPlotPane() {
+        let uri = vscode.Uri.parse('jlplotpane://nothing.html');
+        vscode.commands.executeCommand('vscode.previewHtml', uri, undefined, "julia Plot Pane");
+    }
+    
+    public plotPanePrev() {
+        if(this.currentPlotIndex>0) {
+            this.currentPlotIndex = this.currentPlotIndex - 1;
+            this.update();
+        }
+    }
+    
+    public plotPaneNext() {
+        if(this.currentPlotIndex<this.plots.length-1) {
+            this.currentPlotIndex = this.currentPlotIndex + 1;
+            this.update();
+        }
+    }
+    
+    public plotPaneFirst() {
+        if(this.plots.length>0) {
+            this.currentPlotIndex = 0;
+            this.update();
+        }
+    }
+    
+    public plotPaneLast() {
+        if(this.plots.length>0) {
+            this.currentPlotIndex = this.plots.length - 1;
+            this.update();
+        }
+    }
+    
+    public plotPaneDel() {
+        if(this.plots.length>0) {
+            this.plots.splice(this.currentPlotIndex,1);
+            if(this.currentPlotIndex>this.plots.length-1) {
+                this.currentPlotIndex = this.plots.length - 1;
+            }
+            this.update();
+        }
+    }
+}
+
+function generatePipeName(pid: string, name:string) {
+    if (process.platform === 'win32') {
+        return '\\\\.\\pipe\\' + name + '-' + pid;
+    }
+    else {
+        return path.join(os.tmpdir(), name + '-' + pid);
+    }
+}
+
+export class REPLHandler implements vscode.TreeDataProvider<string> {
+    public terminal: vscode.Terminal = null
+    private extensionPath
+    private juliaExecutable
+    public plotPaneProvider: PlotPaneDocumentContentProvider = new PlotPaneDocumentContentProvider();
+    private variables:string = ''
+
+
+    constructor(extensionPath, juliaExecutable) {
+        this.extensionPath = extensionPath
+        this.juliaExecutable = juliaExecutable
+    }
+
+    getChildren(node?: string) {
+        if (node) {
+            return [node]
+        }
+        else {
+            if (this.terminal) {
+                return [this.variables]
+            }
+            else {
+                return ['no repl attached']
+            }
+        }
+    }
+
+    getTreeItem(node: string): vscode.TreeItem {
+        let treeItem: vscode.TreeItem = new vscode.TreeItem(node)
+        return treeItem;
+    }
+
+    public startREPL() {
+        if (this.terminal==null) {
+            this.startREPLConn()
+            this.startPlotDisplayServer()
+            let args = path.join(this.extensionPath, 'scripts', 'terminalserver', 'terminalserver.jl')
+            this.terminal = vscode.window.createTerminal("julia", this.juliaExecutable, ['-q', '-i', args, process.pid.toString()]);
+        }
+        this.terminal.show();
+    }
+
+    private startREPLConn() {
+        let PIPE_PATH = generatePipeName(process.pid.toString(), 'vscode-language-julia-fromrepl');
+        let replhandler = this
+    
+        var server = net.createServer(function(stream) {
+            let accumulatingBuffer = new Buffer(0);
+    
+            stream.on('data', async function(c) {
+                accumulatingBuffer = Buffer.concat([accumulatingBuffer, Buffer.from(c)]);
+                let replResponse = accumulatingBuffer.toString().split(",")
+    
+                if (replResponse[0] == "repl/returnModules") 
+                {
+                    let result = await vscode.window.showQuickPick(replResponse.slice(1), {placeHolder: 'Switch to Module...'})
+                    if (result!=undefined) {
+                        replhandler.sendMessage('repl/changeModule: ' + result)
+                    }
+                }
+                if (replResponse[0] == "repl/variableList") 
+                {
+                    vscode.window.showInformationMessage(replResponse.slice(1).join(","))
+                }
+                if (replResponse[0] == "repl/variables") 
+                {
+                    replhandler.variables = replResponse[1]
+                    // replhandler.refresh()
+                }
+            });
+        });
+    
+        server.on('close',function(){
+            console.log('Server: on close');
+        })
+    
+        server.listen(PIPE_PATH, function(){
+            console.log('Server: on listening');
+        })
+    }
+
+    startPlotDisplayServer() {
+        let PIPE_PATH = generatePipeName(process.pid.toString(), 'vscode-language-julia-terminal');
+
+        let plotPaneProvider = this.plotPaneProvider
+    
+        var server = net.createServer(function(stream) {
+            let accumulatingBuffer = new Buffer(0);
+    
+            stream.on('data', function(c) {
+                accumulatingBuffer = Buffer.concat([accumulatingBuffer, Buffer.from(c)]);
+                let s = accumulatingBuffer.toString();
+                let index_of_sep_1 = s.indexOf(":");
+                let index_of_sep_2 = s.indexOf(";");
+    
+                if(index_of_sep_2>-1) {
+                    let mime_type = s.substring(0,index_of_sep_1);
+                    let msg_len_as_string = s.substring(index_of_sep_1+1,index_of_sep_2);
+                    let msg_len = parseInt(msg_len_as_string);
+                    if(accumulatingBuffer.length>=mime_type.length+msg_len_as_string.length+2+msg_len) {
+                        let actual_image = s.substring(index_of_sep_2+1);
+                        if(accumulatingBuffer.length > mime_type.length+msg_len_as_string.length+2+msg_len) {
+                            accumulatingBuffer = Buffer.from(accumulatingBuffer.slice(mime_type.length+msg_len_as_string.length+2+msg_len + 1));
+                        }
+                        else {
+                            accumulatingBuffer = new Buffer(0);
+                        }
+    
+                        if(mime_type=='image/svg+xml') {
+                            plotPaneProvider.currentPlotIndex = plotPaneProvider.plots.push(actual_image)-1;
+                        }
+                        else if(mime_type=='image/png') {
+                            let plotPaneContent = '<html><img src="data:image/png;base64,' + actual_image + '" /></html>';
+                            plotPaneProvider.currentPlotIndex = plotPaneProvider.plots.push(plotPaneContent)-1;
+                        }
+                        else {
+                            throw new Error();
+                        }
+                        
+                        let uri = vscode.Uri.parse('jlplotpane://nothing.html');
+                        plotPaneProvider.update();
+                        vscode.commands.executeCommand('vscode.previewHtml', uri, undefined, "julia Plot Pane");
+                    }
+                }
+            });
+        });
+    
+        server.on('close',function(){
+            console.log('Server: on close');
+        })
+    
+        server.listen(PIPE_PATH,function(){
+            console.log('Server: on listening');
+        })
+    }
+
+    public executeCode() {
+        var editor = vscode.window.activeTextEditor;
+        if(!editor) {
+            return;
+        }
+    
+        var selection = editor.selection;
+    
+        var text = selection.isEmpty ? editor.document.lineAt(selection.start.line).text : editor.document.getText(selection);
+    
+        // If no text was selected, try to move the cursor to the end of the next line
+        if (selection.isEmpty) {
+            for (var line = selection.start.line+1; line < editor.document.lineCount; line++) {
+            if (!editor.document.lineAt(line).isEmptyOrWhitespace) {
+                var newPos = selection.active.with(line, editor.document.lineAt(line).range.end.character);
+                var newSel = new vscode.Selection(newPos, newPos);
+                editor.selection = newSel;
+                break;
+            }
+            }
+        }
+    
+        // This is the version that sends code to the REPL directly
+        var lines = text.split(/\r?\n/);
+        lines = lines.filter(line=>line!='');
+        text = lines.join('\n');
+    
+        if(!text.endsWith("\n")) {
+            text = text + '\n';
+        }
+    
+        this.startREPL();
+        this.terminal.show(true);
+        this.terminal.sendText(text, false);
+    }
+
+    public sendMessage(msg: string) {
+        this.startREPL()
+        let sock = generatePipeName(process.pid.toString(), 'vscode-language-julia-torepl')
+    
+        let conn = net.connect(sock)
+        conn.write(msg + "\n")
+        conn.on('error', () => {vscode.window.showErrorMessage("REPL is not open")})
+    }
+}
+
+

--- a/src/weave.ts
+++ b/src/weave.ts
@@ -1,0 +1,167 @@
+import * as vscode from 'vscode';
+import { spawn, ChildProcess } from 'child_process';
+import * as path from 'path';
+import * as fs from 'async-file';
+
+var tempfs = require('promised-temp').track();
+var kill = require('async-child-process').kill;
+
+export class WeaveDocumentContentProvider implements vscode.TextDocumentContentProvider {
+    private juliaExecutable
+    private extensionPath
+    private _onDidChange = new vscode.EventEmitter<vscode.Uri>();
+    private lastWeaveContent: string = null;
+    private weaveOutputChannel: vscode.OutputChannel = null;
+    private weaveChildProcess: ChildProcess = null;
+    private weaveNextChildProcess: ChildProcess = null;
+
+    constructor(extensionPath, juliaExecutable) {
+        this.extensionPath = extensionPath
+        this.juliaExecutable = juliaExecutable
+    }
+
+    public provideTextDocumentContent(uri: vscode.Uri): string {
+        return this.lastWeaveContent;
+    }
+
+    get onDidChange(): vscode.Event<vscode.Uri> {
+        return this._onDidChange.event;
+    }
+
+    public update() {
+        this._onDidChange.fire(vscode.Uri.parse('jlweave://nothing.html'));
+    }
+    
+    async weave_core(column, selected_format:string=undefined) {
+        let parsed_filename = path.parse(vscode.window.activeTextEditor.document.fileName);
+        let weaveProvider = this
+    
+        let source_filename: string;
+        let output_filename: string;
+        if (selected_format===undefined) {
+            let temporary_dirname = await tempfs.mkdir("julia-vscode-weave");
+    
+            source_filename = path.join(temporary_dirname, 'source-file.jmd')
+    
+            await fs.writeFile(source_filename, vscode.window.activeTextEditor.document.getText(), 'utf8');
+        
+            output_filename = path.join(temporary_dirname, 'output-file.html');
+        }
+        else {
+            source_filename = vscode.window.activeTextEditor.document.fileName;
+            output_filename = '';
+        }
+    
+        if (this.weaveOutputChannel == null) {
+            this.weaveOutputChannel = vscode.window.createOutputChannel("julia Weave");
+        }
+        this.weaveOutputChannel.clear();
+        this.weaveOutputChannel.show(true);
+    
+        if (this.weaveChildProcess != null) {
+            try {
+                await kill(this.weaveChildProcess);
+            }
+            catch (e) {
+            }
+        }
+    
+        if (this.weaveNextChildProcess == null) {
+            this.weaveNextChildProcess = spawn(this.juliaExecutable, [path.join(this.extensionPath, 'scripts', 'weave', 'run_weave.jl')]);
+        }
+        this.weaveChildProcess = this.weaveNextChildProcess;
+    
+        this.weaveChildProcess.stdin.write(source_filename + '\n');
+        this.weaveChildProcess.stdin.write(output_filename + '\n');
+        if (selected_format===undefined) {
+            this.weaveChildProcess.stdin.write('PREVIEW\n');
+        }
+        else {
+            this.weaveChildProcess.stdin.write(selected_format + '\n');
+        }
+    
+        weaveProvider.weaveNextChildProcess = spawn(this.juliaExecutable, [path.join(weaveProvider.extensionPath, 'scripts', 'weave', 'run_weave.jl')]);
+    
+        weaveProvider.weaveChildProcess.stdout.on('data', function (data) {
+            weaveProvider.weaveOutputChannel.append(String(data));
+        });
+        weaveProvider.weaveChildProcess.stderr.on('data', function (data) {
+            weaveProvider.weaveOutputChannel.append(String(data));
+        });
+        weaveProvider.weaveChildProcess.on('close', async function (code) {
+            weaveProvider.weaveChildProcess = null;
+    
+            if (code == 0) {
+                weaveProvider.weaveOutputChannel.hide();
+    
+                if (selected_format===undefined) {
+                    weaveProvider.lastWeaveContent = await fs.readFile(output_filename, "utf8")
+    
+                    let uri = vscode.Uri.parse('jlweave://nothing.html');
+                    weaveProvider.update();
+                    let success = await vscode.commands.executeCommand('vscode.previewHtml', uri, column, "julia Weave Preview");
+                }
+            }
+            else {
+                vscode.window.showErrorMessage("Error during weaving.");
+            }
+    
+        });
+    }
+    
+    async open_preview() {
+        if (vscode.window.activeTextEditor === undefined) {
+            vscode.window.showErrorMessage('Please open a document before you execute the weave command.');
+        }
+        else if (vscode.window.activeTextEditor.document.languageId!='juliamarkdown') {
+            vscode.window.showErrorMessage('Only julia Markdown (.jmd) files can be weaved.');
+        }
+        else {
+            this.weave_core(vscode.ViewColumn.One);
+        }
+    }
+    
+    async open_preview_side() {
+        if (vscode.window.activeTextEditor === undefined) {
+            vscode.window.showErrorMessage('Please open a document before you execute the weave command.');
+        }
+        else if (vscode.window.activeTextEditor.document.languageId!='juliamarkdown') {
+            vscode.window.showErrorMessage('Only julia Markdown (.jmd) files can be weaved.');
+        }
+        else {
+            this.weave_core(vscode.ViewColumn.Two);
+        }
+    }
+    
+    async save() {
+        if (vscode.window.activeTextEditor === undefined) {
+            vscode.window.showErrorMessage('Please open a document before you execute the weave command.');
+        }
+        else if (vscode.window.activeTextEditor.document.languageId!='juliamarkdown') {
+            vscode.window.showErrorMessage('Only julia Markdown (.jmd) files can be weaved.');
+        }
+        else if (vscode.window.activeTextEditor.document.isDirty || vscode.window.activeTextEditor.document.isUntitled) {
+            vscode.window.showErrorMessage('Please save the file before weaving.');
+        }
+        else {
+            let formats = ['github: Github markdown',
+                'md2tex: Julia markdown to latex',
+                'pandoc2html: Markdown to HTML (requires Pandoc)',
+                'pandoc: Pandoc markdown',
+                'pandoc2pdf: Pandoc markdown',
+                'tex: Latex with custom code environments',
+                'texminted: Latex using minted for highlighting',
+                'md2html: Julia markdown to html',
+                'rst: reStructuredText and Sphinx',
+                'multimarkdown: MultiMarkdown',
+                'md2pdf: Julia markdown to latex',
+                'asciidoc: AsciiDoc'];
+            let result_format = await vscode.window.showQuickPick(formats, {placeHolder: 'Select output format'});
+            if (result_format!=undefined) {
+                let index = result_format.indexOf(':');
+                let selected_format = result_format.substring(0,index);
+                this.weave_core(vscode.ViewColumn.One, selected_format);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Creates classes for weave/repl functionality so that they can be moved into seperate files.
 I don't know much about typescript/OOP design so a quick review over the style is probably prudent.

I've added some infrastructure to have a REPL variables tree view but can't quite work out how to get the tree to update. I think it should work so that
1) hitting enter/a REPL eval sends an update of what variables are in the current module [here](https://github.com/ZacLN/julia-vscode/blob/refactor/scripts/terminalserver/terminalserver.jl#L27)
2) This message is picked up on the TS side [here](https://github.com/ZacLN/julia-vscode/blob/refactor/src/repl.ts#L145)
3) This should update the TreeDataProvider (this I haven't worked out)

After this is all working we should be able to set it up to click on variables and either access fields (i.e. type instances and modules) or get a display of the variable (i.e. a summary display of the object).