### PR TITLE
add execute block command, return to active editor after any execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,6 +170,10 @@
             {
                 "command": "language-julia.toggle-log",
                 "title": "Julia: Toggle server logs"
+            },
+            {
+                "command": "language-julia.executeJuliaBlockInREPL",
+                "title": "Julia: Execute Block"
             }
         ],
         "menus": {

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -217,7 +217,17 @@ export class REPLHandler implements vscode.TreeDataProvider<string> {
         })
     }
 
-    public executeCode() {
+    public executeCode(text) {
+        if(!text.endsWith("\n")) {
+            text = text + '\n';
+        }
+    
+        this.startREPL();
+        this.terminal.show(true);
+        this.terminal.sendText(text, false);
+    }
+
+    public executeSelection() {
         var editor = vscode.window.activeTextEditor;
         if(!editor) {
             return;
@@ -243,14 +253,8 @@ export class REPLHandler implements vscode.TreeDataProvider<string> {
         var lines = text.split(/\r?\n/);
         lines = lines.filter(line=>line!='');
         text = lines.join('\n');
-    
-        if(!text.endsWith("\n")) {
-            text = text + '\n';
-        }
-    
-        this.startREPL();
-        this.terminal.show(true);
-        this.terminal.sendText(text, false);
+        this.executeCode(text)
+        editor.show()
     }
 
     public executeFile() {
@@ -259,9 +263,8 @@ export class REPLHandler implements vscode.TreeDataProvider<string> {
             return;
         }
         let text = editor.document.getText()
-        this.startREPL();
-        this.terminal.show(true);
-        this.terminal.sendText(text, false);
+        this.executeCode(text)
+        editor.show()
     }
 
     public sendMessage(msg: string) {


### PR DESCRIPTION
The new command executes the toplevel block that the start of any selection sits in. We may want to give options to determine code eval behaviour. e.g.:
- if there's a selection, eval it
- if no selection do we eval the line or block?

Also switches context back to the active editor after any eval