### PR TITLE
Fix typescript rearrangement

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,178 +6,108 @@ import * as fs from 'async-file';
 import * as path from 'path'
 import * as net from 'net';
 import * as os from 'os';
-var kill = require('async-child-process').kill;
-var exec = require('child-process-promise').exec;
-var tempfs = require('promised-temp').track();
 import { spawn, ChildProcess } from 'child_process';
 import { LanguageClient, LanguageClientOptions, SettingMonitor, ServerOptions, TransportKind, StreamInfo } from 'vscode-languageclient';
 import * as vslc from 'vscode-languageclient';
 import * as rpc from 'vscode-jsonrpc';
-import { REPLHandler, PlotPaneDocumentContentProvider } from './repl'
-import { WeaveDocumentContentProvider } from './weave'
+import * as repl from './repl';
+import * as weave from './weave';
+import * as tasks from './tasks';
+import * as settings from './settings';
+import * as smallcommands from './smallcommands';
+import * as packagepath from './packagepath';
+import * as openpackagedirectory from './openpackagedirectory';
 
-let juliaExecutable = null;
-let juliaPackagePath: string = null;
-let languageClient: LanguageClient = null;
-let extensionPath: string = null;
+let g_settings: settings.ISettings = null;
+let g_languageClient: LanguageClient = null;
 let g_context: vscode.ExtensionContext = null;
-let serverstatus: vscode.StatusBarItem = null;
-let serverBusyNotification = new rpc.NotificationType<string, void>('window/setStatusBusy');
-let serverReadyNotification = new rpc.NotificationType<string, void>('window/setStatusReady');
-let taskProvider: vscode.Disposable | undefined;
 
-export interface TextDocumentPositionParams {
-    textDocument: vslc.TextDocumentIdentifier
-    position: vscode.Position
-}
-
-let getBlockText = new rpc.RequestType<TextDocumentPositionParams, void,void,void>('julia/getCurrentBlockText')
+let g_serverstatus: vscode.StatusBarItem = null;
+let g_serverBusyNotification = new rpc.NotificationType<string, void>('window/setStatusBusy');
+let g_serverReadyNotification = new rpc.NotificationType<string, void>('window/setStatusReady');
 
 export function activate(context: vscode.ExtensionContext) {
     g_context = context;
-    extensionPath = context.extensionPath;
+
     console.log('Activating extension language-julia');
 
-    loadConfiguration();
-    
-    // REPL
-    // const replTree = new REPLTree(context);
-    let repl = new REPLHandler(extensionPath, juliaExecutable)
-    context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider('jlplotpane', repl.plotPaneProvider));
-    vscode.window.registerTreeDataProvider('REPLVariables', repl);
-    
-    context.subscriptions.push(vscode.commands.registerCommand('language-julia.startREPL', () => {repl.startREPL()}));
-    context.subscriptions.push(vscode.commands.registerCommand('language-julia.executeJuliaCodeInREPL', () => {repl.executeSelection()}));
-    context.subscriptions.push(vscode.commands.registerCommand('language-julia.executeJuliaFileInREPL', () => {repl.executeFile()}));
-    context.subscriptions.push(vscode.commands.registerCommand('language-julia.change-repl-module', () => {
-        repl.sendMessage('repl/getAvailableModules', '')
-        vscode.window.showTextDocument(vscode.window.activeTextEditor.document)
-    }));
-    context.subscriptions.push(vscode.commands.registerCommand('language-julia.executeJuliaBlockInREPL', () => {
-        var editor = vscode.window.activeTextEditor;
-        let params : TextDocumentPositionParams = {textDocument: vslc.TextDocumentIdentifier.create(editor.document.uri.toString()), position: new vscode.Position(editor.selection.start.line, editor.selection.start.character)}
-        languageClient.sendRequest('julia/getCurrentBlockText', params).then((text)=>{
-            repl.executeCode(text)
-            vscode.window.showTextDocument(vscode.window.activeTextEditor.document)
-        })
-    }));
-
-    context.subscriptions.push(vscode.commands.registerCommand('language-julia.show-plotpane', repl.plotPaneProvider.showPlotPane));
-    context.subscriptions.push(vscode.commands.registerCommand('language-julia.plotpane-previous', repl.plotPaneProvider.plotPanePrev));
-    context.subscriptions.push(vscode.commands.registerCommand('language-julia.plotpane-next', repl.plotPaneProvider.plotPaneNext));
-    context.subscriptions.push(vscode.commands.registerCommand('language-julia.plotpane-first', repl.plotPaneProvider.plotPaneFirst));
-    context.subscriptions.push(vscode.commands.registerCommand('language-julia.plotpane-last', repl.plotPaneProvider.plotPaneLast));
-    context.subscriptions.push(vscode.commands.registerCommand('language-julia.plotpane-delete', repl.plotPaneProvider.plotPaneDel));
-
+    g_settings = settings.loadSettings();
 
     // Status bar
-    serverstatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);   
-    serverstatus.show()
-    serverstatus.text = 'Julia: starting up';
-    context.subscriptions.push(serverstatus);
+    g_serverstatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+    g_serverstatus.show()
+    g_serverstatus.text = 'Julia: starting up';
+    context.subscriptions.push(g_serverstatus);
 
-
-    // Weave
-    let weaveProvider = new WeaveDocumentContentProvider(extensionPath, juliaExecutable);
-    context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider('jlweave', weaveProvider));
-    context.subscriptions.push(vscode.commands.registerCommand('language-julia.weave-open-preview', ()=>{weaveProvider.open_preview()}));
-    context.subscriptions.push(vscode.commands.registerCommand('language-julia.weave-open-preview-side', ()=>{weaveProvider.open_preview_side}));
-    context.subscriptions.push(vscode.commands.registerCommand('language-julia.weave-save', ()=>{weaveProvider.save}));
-
-
-    // Misc. commands
+    // Config change
     context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(configChanged));
-    context.subscriptions.push(vscode.commands.registerCommand('language-julia.openPackageDirectory', openPackageDirectoryCommand));
-    context.subscriptions.push(vscode.commands.registerCommand('language-julia.applytextedit', applyTextEdit));
-    context.subscriptions.push(vscode.commands.registerCommand('language-julia.lint-package', lintPackage));
-    context.subscriptions.push(vscode.commands.registerCommand('language-julia.toggleLinter', toggleLinter));
-    context.subscriptions.push(vscode.commands.registerCommand('language-julia.reload-modules', reloadModules));
-    context.subscriptions.push(vscode.commands.registerCommand('language-julia.toggle-log', toggleServerLogs));
-    context.subscriptions.push(vscode.commands.registerCommand('language-julia.toggle-file-lint', (arg) => {
-        try {
-            languageClient.sendRequest("julia/toggleFileLint", arg);
-        }
-        catch(ex) {5
-            if(ex.message=="Language client is not ready yet") {
-                vscode.window.showErrorMessage('Error: server is not running.');
-            }
-            else {
-                throw ex;
-            }
-        }
 
-    }));
-
-    vscode.window.onDidCloseTerminal(terminal=>{
-        if (terminal==repl.terminal) {
-            repl.terminal = null;
-        }
-    })
+    // Language settings
     vscode.languages.setLanguageConfiguration('julia', {
         indentationRules: {
             increaseIndentPattern: /^(\s*|.*=\s*|.*@\w*\s*)[\w\s]*\b(if|while|for|function|macro|immutable|struct|type|let|quote|try|begin|.*\)\s*do|else|elseif|catch|finally)\b(?!.*\bend\b[^\]]*$).*$/,
             decreaseIndentPattern: /^\s*(end|else|elseif|catch|finally)\b.*$/
         }
     });
-    startLanguageServer();
 
-    taskProvider = vscode.workspace.registerTaskProvider('julia', {
-        provideTasks: () => {
-            return getJuliaTasks();
-        },
-        resolveTask(_task: vscode.Task): vscode.Task | undefined {
-            return undefined;
-        }
-    });
+    // Active features from other files
+    repl.activate(context, g_settings);
+    weave.activate(context, g_settings);
+    tasks.activate(context, g_settings);
+    smallcommands.activate(context, g_settings);
+    packagepath.activate(context, g_settings);
+    openpackagedirectory.activate(context, g_settings);
+
+    // Start language server
+    startLanguageServer();
 }
 
 // this method is called when your extension is deactivated
 export function deactivate() {
 }
 
+function setLanguageClient(languageClient:vslc.LanguageClient) {
+    g_languageClient = languageClient;
+
+    repl.onNewLanguageClient(g_languageClient);
+    weave.onNewLanguageClient(g_languageClient);
+    tasks.onNewLanguageClient(g_languageClient);
+    smallcommands.onNewLanguageClient(g_languageClient);
+    packagepath.onNewLanguageClient(g_languageClient);
+    openpackagedirectory.onNewLanguageClient(g_languageClient);
+}
+
 function configChanged(params) {
-    let need_to_restart_server = loadConfiguration();
+    let newSettings = settings.loadSettings();
+
+    repl.onDidChangeConfiguration(newSettings);
+    weave.onDidChangeConfiguration(newSettings);
+    tasks.onDidChangeConfiguration(newSettings);
+    smallcommands.onDidChangeConfiguration(newSettings);
+    packagepath.onDidChangeConfiguration(newSettings);
+    openpackagedirectory.onDidChangeConfiguration(newSettings);
+
+    let need_to_restart_server = false;
+
+    if (g_settings.juliaExePath != newSettings.juliaExePath) {
+        need_to_restart_server = true;
+    }
 
     if(need_to_restart_server) {
-        if(languageClient!=null) {
-            languageClient.stop();
-            languageClient = null;
+        if(g_languageClient!=null) {
+            g_languageClient.stop();
+            setLanguageClient(null);
         }
 
         startLanguageServer();
     }
 }
 
-function loadConfiguration() {
-    let oldValue = juliaExecutable;
-
-    let section = vscode.workspace.getConfiguration('julia');
-    if (section) {
-        juliaExecutable = section.get<string>('executablePath', null);
-    }
-    else {
-        juliaExecutable = null;
-    }
-
-    if(juliaExecutable != oldValue) {
-        juliaPackagePath = null;
-    }
-    return juliaExecutable != oldValue
-}
-
-async function getPkgPath() {
-    if(juliaPackagePath==null) {
-        var res = await exec(`"${juliaExecutable}" -e "println(Pkg.dir())"`);
-        juliaPackagePath = res.stdout.trim();
-    }
-    return juliaPackagePath;
-}
-
 async function startLanguageServer() {
     // let debugOptions = { execArgv: ["--nolazy", "--debug=6004"] };
 
     try {
-        var originalJuliaPkgDir = await getPkgPath();
+        var originalJuliaPkgDir = await packagepath.getPkgPath();
     }
     catch (e) {
         vscode.window.showErrorMessage('Could not start the julia language server. Make sure the configuration setting julia.executablePath points to the julia binary.');
@@ -186,17 +116,16 @@ async function startLanguageServer() {
     let serverArgsRun = ['--startup-file=no', '--history-file=no', 'main.jl', originalJuliaPkgDir, '--debug=no'];
     let serverArgsDebug = ['--startup-file=no', '--history-file=no', 'main.jl', originalJuliaPkgDir, '--debug=yes'];
     let spawnOptions = {
-        cwd: path.join(extensionPath, 'scripts', 'languageserver'),
+        cwd: path.join(g_context.extensionPath, 'scripts', 'languageserver'),
         env: {
-            JULIA_PKGDIR: path.join(extensionPath, 'scripts', 'languageserver', 'julia_pkgdir'),
+            JULIA_PKGDIR: path.join(g_context.extensionPath, 'scripts', 'languageserver', 'julia_pkgdir'),
             HOME: process.env.HOME ? process.env.HOME : os.homedir()
         }
     };
 
-
     let serverOptions = {
-        run: { command: juliaExecutable, args: serverArgsRun, options: spawnOptions },
-        debug: { command: juliaExecutable, args: serverArgsDebug, options: spawnOptions }
+        run: { command: g_settings.juliaExePath, args: serverArgsRun, options: spawnOptions },
+        debug: { command: g_settings.juliaExePath, args: serverArgsDebug, options: spawnOptions }
     };
 
     let clientOptions: LanguageClientOptions = {
@@ -208,159 +137,21 @@ async function startLanguageServer() {
     }
 
     // Create the language client and start the client.
-    languageClient = new LanguageClient('julia Language Server', serverOptions, clientOptions);
+    g_languageClient = new LanguageClient('julia Language Server', serverOptions, clientOptions);
 
-    // Push the disposable to the context's subscriptions so that the 
+    // Push the disposable to the context's subscriptions so that the
     // client can be deactivated on extension deactivation
     try {
-        g_context.subscriptions.push(languageClient.start());
+        g_context.subscriptions.push(g_languageClient.start());
+        setLanguageClient(g_languageClient);
     }
     catch (e) {
         vscode.window.showErrorMessage('Could not start the julia language server. Make sure the configuration setting julia.executablePath points to the julia binary.');
-        languageClient = null;
+        g_languageClient = null;
     }
-    languageClient.onReady().then(()=>{
-        languageClient.onNotification(serverBusyNotification, ()=>{serverstatus.text = 'Julia: busy'})
-        languageClient.onNotification(serverReadyNotification, ()=>{serverstatus.text = 'Julia: ready'})
+
+    g_languageClient.onReady().then(()=>{
+        g_languageClient.onNotification(g_serverBusyNotification, ()=>{g_serverstatus.text = 'Julia: busy'})
+        g_languageClient.onNotification(g_serverReadyNotification, ()=>{g_serverstatus.text = 'Julia: ready'})
     })
-}
-
-// This method implements the language-julia.openPackageDirectory command
-async function openPackageDirectoryCommand() {
-    const optionsPackage: vscode.QuickPickOptions = {
-        placeHolder: 'Select package'
-    };
-
-    try {
-        var juliaVersionHomeDir = await getPkgPath();        
-
-        let files = await fs.readdir(juliaVersionHomeDir);
-
-        let filteredPackages = files.filter(path => !path.startsWith('.') && ['METADATA', 'REQUIRE', 'META_BRANCH'].indexOf(path) < 0);
-
-        if (filteredPackages.length == 0) {
-            vscode.window.showInformationMessage('Error: There are no packages installed.');
-        }
-        else {
-            let resultPackage = await vscode.window.showQuickPick(filteredPackages, optionsPackage);
-
-            if (resultPackage !== undefined) {
-                var folder = vscode.Uri.file(path.join(juliaVersionHomeDir, resultPackage));
-
-                try {
-                    await vscode.commands.executeCommand('vscode.openFolder', folder, true);
-                }
-                catch (e) {
-                    vscode.window.showInformationMessage('Could not open the package.');
-                }
-            }
-        }
-    }
-    catch (e) {
-        vscode.window.showInformationMessage('Error: Could not read package directory.');
-    }
-}
-
-export function toggleLinter() {
-    let cval = vscode.workspace.getConfiguration('julia').get('runlinter', false)
-    vscode.workspace.getConfiguration('julia').update('runlinter', !cval, true)
-}
-
-export function applyTextEdit(we) {
-    let wse = new vscode.WorkspaceEdit()
-    for (let edit of we.documentChanges[0].edits) {
-        wse.replace(we.documentChanges[0].textDocument.uri, new vscode.Range(edit.range.start.line, edit.range.start.character, edit.range.end.line, edit.range.end.character), edit.newText)
-    }
-    vscode.workspace.applyEdit(wse)
-}
-
-export function lintPackage() {
-    try {
-        languageClient.sendRequest("julia/lint-package");
-    }
-    catch(ex) {
-        if(ex.message=="Language client is not ready yet") {
-            vscode.window.showErrorMessage('Error: package linting only works with a running julia language server.');
-        }
-        else {
-            throw ex;
-        }
-    }
-}
-
-export function reloadModules() {
-    try {
-        languageClient.sendRequest("julia/reload-modules");
-    }
-    catch(ex) {
-        if(ex.message=="Language client is not ready yet") {
-            vscode.window.showErrorMessage('Error: Language server is not yet running.');
-        }
-        else {
-            throw ex;
-        }
-    }
-}
-
-async function getJuliaTasks(): Promise<vscode.Task[]> {
-    let workspaceRoot = vscode.workspace.rootPath;
-
-    let emptyTasks: vscode.Task[] = [];
-
-    if (!workspaceRoot) {
-        return emptyTasks;
-    }
-
-    try {
-        const result: vscode.Task[] = [];
-
-        if (await fs.exists(path.join(workspaceRoot, 'test', 'runtests.jl'))) {
-            let testTask = new vscode.Task({ type: 'julia', command: 'test' }, `Run tests`, 'julia', new vscode.ProcessExecution(juliaExecutable, ['--color=yes', '-e', 'Pkg.test(Base.ARGS[1])', vscode.workspace.rootPath]), "");
-            testTask.group = vscode.TaskGroup.Test;
-            testTask.presentationOptions = { echo: false };
-            result.push(testTask);
-        }
-
-        if (await fs.exists(path.join(workspaceRoot, 'deps', 'build.jl'))) {
-            let splitted_path = vscode.workspace.rootPath.split(path.sep);
-            let package_name = splitted_path[splitted_path.length-1];
-            let buildTask = new vscode.Task({ type: 'julia', command: 'build'}, `Run build`, 'julia', new vscode.ProcessExecution(juliaExecutable, ['--color=yes', '-e', 'Pkg.build(Base.ARGS[1])', package_name]), "");
-            buildTask.group = vscode.TaskGroup.Build;
-            buildTask.presentationOptions = { echo: false };
-            result.push(buildTask);
-        }
-
-        if (await fs.exists(path.join(workspaceRoot, 'benchmark', 'benchmarks.jl'))) {
-            let splitted_path = vscode.workspace.rootPath.split(path.sep);
-            let package_name = splitted_path[splitted_path.length-1];
-            let benchmarkTask = new vscode.Task({ type: 'julia', command: 'benchmark'}, `Run benchmark`, 'julia', new vscode.ProcessExecution(juliaExecutable, ['--color=yes', '-e', 'using PkgBenchmark; benchmarkpkg(Base.ARGS[1], promptsave=false, promptoverwrite=false)', package_name]), "");
-            benchmarkTask.presentationOptions = { echo: false };
-            result.push(benchmarkTask);
-        }
-
-        if (await fs.exists(path.join(workspaceRoot, 'docs', 'make.jl'))) {
-            let buildTask = new vscode.Task({ type: 'julia', command: 'docbuild'}, `Build documentation`, 'julia', new vscode.ProcessExecution(juliaExecutable, ['--color=yes', '-e', 'include(Base.ARGS[1])', path.join(workspaceRoot, 'docs', 'make.jl')]), "");
-            buildTask.group = vscode.TaskGroup.Build;
-            buildTask.presentationOptions = { echo: false };
-            result.push(buildTask);
-        }
-
-        return Promise.resolve(result);
-    } catch (e) {
-        return Promise.resolve(emptyTasks);
-    }
-}
-
-export function toggleServerLogs() {
-    try {
-        languageClient.sendRequest("julia/toggle-log");
-    }
-    catch(ex) {
-        if(ex.message=="Language client is not ready yet") {
-            vscode.window.showErrorMessage('Error: server is not running.');
-        }
-        else {
-            throw ex;
-        }
-    }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,7 +66,7 @@ export function activate(context: vscode.ExtensionContext) {
 export function deactivate() {
 }
 
-function setLanguageClient(languageClient:vslc.LanguageClient) {
+function setLanguageClient(languageClient: vslc.LanguageClient) {
     g_languageClient = languageClient;
 
     repl.onNewLanguageClient(g_languageClient);
@@ -93,8 +93,8 @@ function configChanged(params) {
         need_to_restart_server = true;
     }
 
-    if(need_to_restart_server) {
-        if(g_languageClient!=null) {
+    if (need_to_restart_server) {
+        if (g_languageClient != null) {
             g_languageClient.stop();
             setLanguageClient(null);
         }
@@ -150,8 +150,8 @@ async function startLanguageServer() {
         g_languageClient = null;
     }
 
-    g_languageClient.onReady().then(()=>{
-        g_languageClient.onNotification(g_serverBusyNotification, ()=>{g_serverstatus.text = 'Julia: busy'})
-        g_languageClient.onNotification(g_serverReadyNotification, ()=>{g_serverstatus.text = 'Julia: ready'})
+    g_languageClient.onReady().then(() => {
+        g_languageClient.onNotification(g_serverBusyNotification, () => { g_serverstatus.text = 'Julia: busy' })
+        g_languageClient.onNotification(g_serverReadyNotification, () => { g_serverstatus.text = 'Julia: ready' })
     })
 }

--- a/src/openpackagedirectory.ts
+++ b/src/openpackagedirectory.ts
@@ -1,0 +1,61 @@
+import * as vscode from 'vscode';
+import * as fs from 'async-file';
+import * as path from 'path';
+import * as settings from './settings';
+import * as packagepath from './packagepath'
+import * as vslc from 'vscode-languageclient';
+
+let g_context: vscode.ExtensionContext = null;
+let g_settings: settings.ISettings = null;
+let g_languageClient: vslc.LanguageClient = null;
+
+// This method implements the language-julia.openPackageDirectory command
+async function openPackageDirectoryCommand() {
+    const optionsPackage: vscode.QuickPickOptions = {
+        placeHolder: 'Select package'
+    };
+
+    try {
+        var juliaVersionHomeDir = await packagepath.getPkgPath();
+
+        let files = await fs.readdir(juliaVersionHomeDir);
+
+        let filteredPackages = files.filter(path => !path.startsWith('.') && ['METADATA', 'REQUIRE', 'META_BRANCH'].indexOf(path) < 0);
+
+        if (filteredPackages.length == 0) {
+            vscode.window.showInformationMessage('Error: There are no packages installed.');
+        }
+        else {
+            let resultPackage = await vscode.window.showQuickPick(filteredPackages, optionsPackage);
+
+            if (resultPackage !== undefined) {
+                var folder = vscode.Uri.file(path.join(juliaVersionHomeDir, resultPackage));
+
+                try {
+                    await vscode.commands.executeCommand('vscode.openFolder', folder, true);
+                }
+                catch (e) {
+                    vscode.window.showInformationMessage('Could not open the package.');
+                }
+            }
+        }
+    }
+    catch (e) {
+        vscode.window.showInformationMessage('Error: Could not read package directory.');
+    }
+}
+
+export function activate(context: vscode.ExtensionContext, settings: settings.ISettings) {
+    g_context = context;
+    g_settings = settings;
+
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.openPackageDirectory', openPackageDirectoryCommand));
+}
+
+export function onDidChangeConfiguration(newSettings: settings.ISettings) {
+
+}
+
+export function onNewLanguageClient(newLanguageClient: vslc.LanguageClient) {
+    g_languageClient = newLanguageClient;
+}

--- a/src/packagepath.ts
+++ b/src/packagepath.ts
@@ -1,0 +1,33 @@
+import * as vscode from 'vscode';
+import * as settings from './settings';
+import * as vslc from 'vscode-languageclient';
+var exec = require('child-process-promise').exec;
+
+let g_context: vscode.ExtensionContext = null;
+let g_settings: settings.ISettings = null;
+let g_languageClient: vslc.LanguageClient = null;
+
+let juliaPackagePath: string = null;
+
+export async function getPkgPath() {
+    if(juliaPackagePath==null) {
+        var res = await exec(`"${g_settings.juliaExePath}" -e "println(Pkg.dir())"`);
+        juliaPackagePath = res.stdout.trim();
+    }
+    return juliaPackagePath;
+}
+
+export function activate(context: vscode.ExtensionContext, settings: settings.ISettings) {
+    g_context = context;
+    g_settings = settings;
+}
+
+export function onDidChangeConfiguration(newSettings: settings.ISettings) {
+    if(g_settings.juliaExePath != newSettings.juliaExePath) {
+        juliaPackagePath = null;
+    }
+}
+
+export function onNewLanguageClient(newLanguageClient: vslc.LanguageClient) {
+    g_languageClient = newLanguageClient;
+}

--- a/src/packagepath.ts
+++ b/src/packagepath.ts
@@ -10,7 +10,7 @@ let g_languageClient: vslc.LanguageClient = null;
 let juliaPackagePath: string = null;
 
 export async function getPkgPath() {
-    if(juliaPackagePath==null) {
+    if (juliaPackagePath == null) {
         var res = await exec(`"${g_settings.juliaExePath}" -e "println(Pkg.dir())"`);
         juliaPackagePath = res.stdout.trim();
     }
@@ -23,7 +23,7 @@ export function activate(context: vscode.ExtensionContext, settings: settings.IS
 }
 
 export function onDidChangeConfiguration(newSettings: settings.ISettings) {
-    if(g_settings.juliaExePath != newSettings.juliaExePath) {
+    if (g_settings.juliaExePath != newSettings.juliaExePath) {
         juliaPackagePath = null;
     }
 }

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -19,7 +19,7 @@ export class PlotPaneDocumentContentProvider implements vscode.TextDocumentConte
     private _onDidChange = new vscode.EventEmitter<vscode.Uri>();
 
     public provideTextDocumentContent(uri: vscode.Uri): string {
-        if(g_plots.length==0) {
+        if (g_plots.length == 0) {
             return '<html></html>';
         }
         else {
@@ -44,44 +44,44 @@ export function showPlotPane() {
 }
 
 export function plotPanePrev() {
-    if(g_currentPlotIndex>0) {
+    if (g_currentPlotIndex > 0) {
         g_currentPlotIndex = g_currentPlotIndex - 1;
         g_plotPaneProvider.update();
     }
 }
 
 export function plotPaneNext() {
-    if(g_currentPlotIndex<g_plots.length-1) {
+    if (g_currentPlotIndex < g_plots.length - 1) {
         g_currentPlotIndex = g_currentPlotIndex + 1;
         g_plotPaneProvider.update();
     }
 }
 
 export function plotPaneFirst() {
-    if(g_plots.length>0) {
+    if (g_plots.length > 0) {
         g_currentPlotIndex = 0;
         g_plotPaneProvider.update();
     }
 }
 
 export function plotPaneLast() {
-    if(g_plots.length>0) {
+    if (g_plots.length > 0) {
         g_currentPlotIndex = g_plots.length - 1;
         g_plotPaneProvider.update();
     }
 }
 
 export function plotPaneDel() {
-    if(g_plots.length>0) {
-        g_plots.splice(g_currentPlotIndex,1);
-        if(g_currentPlotIndex>g_plots.length-1) {
+    if (g_plots.length > 0) {
+        g_plots.splice(g_currentPlotIndex, 1);
+        if (g_currentPlotIndex > g_plots.length - 1) {
             g_currentPlotIndex = g_plots.length - 1;
         }
         g_plotPaneProvider.update();
     }
 }
 
-function generatePipeName(pid: string, name:string) {
+function generatePipeName(pid: string, name: string) {
     if (process.platform === 'win32') {
         return '\\\\.\\pipe\\' + name + '-' + pid;
     }
@@ -91,7 +91,7 @@ function generatePipeName(pid: string, name:string) {
 }
 
 export class REPLHandler implements vscode.TreeDataProvider<string> {
-    private variables:string = ''
+    private variables: string = ''
     private _onDidChangeTreeData: vscode.EventEmitter<string | undefined> = new vscode.EventEmitter<string | undefined>();
     readonly onDidChangeTreeData: vscode.Event<string | undefined> = this._onDidChangeTreeData.event;
 
@@ -120,7 +120,7 @@ export class REPLHandler implements vscode.TreeDataProvider<string> {
 }
 
 function startREPL() {
-    if (g_terminal==null) {
+    if (g_terminal == null) {
         startREPLConn()
         startPlotDisplayServer()
         let args = path.join(g_context.extensionPath, 'scripts', 'terminalserver', 'terminalserver.jl')
@@ -133,34 +133,32 @@ function startREPLConn() {
     let PIPE_PATH = generatePipeName(process.pid.toString(), 'vscode-language-julia-fromrepl');
     let replhandler = this
 
-    var server = net.createServer(function(stream) {
+    var server = net.createServer(function (stream) {
         let accumulatingBuffer = new Buffer(0);
 
-        stream.on('data', async function(c) {
+        stream.on('data', async function (c) {
             accumulatingBuffer = Buffer.concat([accumulatingBuffer, Buffer.from(c)]);
             let bufferResult = accumulatingBuffer.toString()
             let replResponse = accumulatingBuffer.toString().split(",")
 
-            if (replResponse[0] == "repl/returnModules")
-            {
-                let result = await vscode.window.showQuickPick(replResponse.slice(1), {placeHolder: 'Switch to Module...'})
-                if (result!=undefined) {
-                    replhandler.sendMessage('repl/changeModule',result)
+            if (replResponse[0] == "repl/returnModules") {
+                let result = await vscode.window.showQuickPick(replResponse.slice(1), { placeHolder: 'Switch to Module...' })
+                if (result != undefined) {
+                    replhandler.sendMessage('repl/changeModule', result)
                 }
             }
-            if (replResponse[0] == "repl/variables")
-            {
+            if (replResponse[0] == "repl/variables") {
                 replhandler.variables = bufferResult
                 replhandler.refresh()
             }
         });
     });
 
-    server.on('close',function(){
+    server.on('close', function () {
         console.log('Server: on close');
     })
 
-    server.listen(PIPE_PATH, function(){
+    server.listen(PIPE_PATH, function () {
         console.log('Server: on listening');
     })
 }
@@ -168,34 +166,34 @@ function startREPLConn() {
 function startPlotDisplayServer() {
     let PIPE_PATH = generatePipeName(process.pid.toString(), 'vscode-language-julia-terminal');
 
-    var server = net.createServer(function(stream) {
+    var server = net.createServer(function (stream) {
         let accumulatingBuffer = new Buffer(0);
 
-        stream.on('data', function(c) {
+        stream.on('data', function (c) {
             accumulatingBuffer = Buffer.concat([accumulatingBuffer, Buffer.from(c)]);
             let s = accumulatingBuffer.toString();
             let index_of_sep_1 = s.indexOf(":");
             let index_of_sep_2 = s.indexOf(";");
 
-            if(index_of_sep_2>-1) {
-                let mime_type = s.substring(0,index_of_sep_1);
-                let msg_len_as_string = s.substring(index_of_sep_1+1,index_of_sep_2);
+            if (index_of_sep_2 > -1) {
+                let mime_type = s.substring(0, index_of_sep_1);
+                let msg_len_as_string = s.substring(index_of_sep_1 + 1, index_of_sep_2);
                 let msg_len = parseInt(msg_len_as_string);
-                if(accumulatingBuffer.length>=mime_type.length+msg_len_as_string.length+2+msg_len) {
-                    let actual_image = s.substring(index_of_sep_2+1);
-                    if(accumulatingBuffer.length > mime_type.length+msg_len_as_string.length+2+msg_len) {
-                        accumulatingBuffer = Buffer.from(accumulatingBuffer.slice(mime_type.length+msg_len_as_string.length+2+msg_len + 1));
+                if (accumulatingBuffer.length >= mime_type.length + msg_len_as_string.length + 2 + msg_len) {
+                    let actual_image = s.substring(index_of_sep_2 + 1);
+                    if (accumulatingBuffer.length > mime_type.length + msg_len_as_string.length + 2 + msg_len) {
+                        accumulatingBuffer = Buffer.from(accumulatingBuffer.slice(mime_type.length + msg_len_as_string.length + 2 + msg_len + 1));
                     }
                     else {
                         accumulatingBuffer = new Buffer(0);
                     }
 
-                    if(mime_type=='image/svg+xml') {
-                        g_currentPlotIndex = g_plots.push(actual_image)-1;
+                    if (mime_type == 'image/svg+xml') {
+                        g_currentPlotIndex = g_plots.push(actual_image) - 1;
                     }
-                    else if(mime_type=='image/png') {
+                    else if (mime_type == 'image/png') {
                         let plotPaneContent = '<html><img src="data:image/png;base64,' + actual_image + '" /></html>';
-                        g_currentPlotIndex = g_plots.push(plotPaneContent)-1;
+                        g_currentPlotIndex = g_plots.push(plotPaneContent) - 1;
                     }
                     else {
                         throw new Error();
@@ -209,31 +207,31 @@ function startPlotDisplayServer() {
         });
     });
 
-    server.on('close',function(){
+    server.on('close', function () {
         console.log('Server: on close');
     })
 
-    server.listen(PIPE_PATH,function(){
+    server.listen(PIPE_PATH, function () {
         console.log('Server: on listening');
     })
 }
 
 function executeCode(text) {
-    if(!text.endsWith("\n")) {
+    if (!text.endsWith("\n")) {
         text = text + '\n';
     }
 
     startREPL();
     g_terminal.show(true);
     var lines = text.split(/\r?\n/);
-    lines = lines.filter(line=>line!='');
+    lines = lines.filter(line => line != '');
     text = lines.join('\n');
     g_terminal.sendText(text + '\n', false);
 }
 
 function executeSelection() {
     var editor = vscode.window.activeTextEditor;
-    if(!editor) {
+    if (!editor) {
         return;
     }
 
@@ -243,13 +241,13 @@ function executeSelection() {
 
     // If no text was selected, try to move the cursor to the end of the next line
     if (selection.isEmpty) {
-        for (var line = selection.start.line+1; line < editor.document.lineCount; line++) {
-        if (!editor.document.lineAt(line).isEmptyOrWhitespace) {
-            var newPos = selection.active.with(line, editor.document.lineAt(line).range.end.character);
-            var newSel = new vscode.Selection(newPos, newPos);
-            editor.selection = newSel;
-            break;
-        }
+        for (var line = selection.start.line + 1; line < editor.document.lineCount; line++) {
+            if (!editor.document.lineAt(line).isEmptyOrWhitespace) {
+                var newPos = selection.active.with(line, editor.document.lineAt(line).range.end.character);
+                var newSel = new vscode.Selection(newPos, newPos);
+                editor.selection = newSel;
+                break;
+            }
         }
     }
     executeCode(text)
@@ -258,7 +256,7 @@ function executeSelection() {
 
 function executeFile() {
     var editor = vscode.window.activeTextEditor;
-    if(!editor) {
+    if (!editor) {
         return;
     }
     sendMessage('repl/include', editor.document.fileName)
@@ -284,7 +282,7 @@ function sendMessage(cmd, msg: string) {
 
     let conn = net.connect(sock)
     conn.write(cmd + '\n' + msg + "\nrepl/endMessage")
-    conn.on('error', () => {vscode.window.showErrorMessage("REPL is not open")})
+    conn.on('error', () => { vscode.window.showErrorMessage("REPL is not open") })
 }
 
 export interface TextDocumentPositionParams {
@@ -292,7 +290,7 @@ export interface TextDocumentPositionParams {
     position: vscode.Position
 }
 
-let getBlockText = new rpc.RequestType<TextDocumentPositionParams, void,void,void>('julia/getCurrentBlockText')
+let getBlockText = new rpc.RequestType<TextDocumentPositionParams, void, void, void>('julia/getCurrentBlockText')
 
 export function activate(context: vscode.ExtensionContext, settings: settings.ISettings) {
     g_context = context;
@@ -329,8 +327,8 @@ export function activate(context: vscode.ExtensionContext, settings: settings.IS
 
     context.subscriptions.push(vscode.commands.registerCommand('language-julia.plotpane-delete', plotPaneDel));
 
-    vscode.window.onDidCloseTerminal(terminal=>{
-        if (terminal==g_terminal) {
+    vscode.window.onDidCloseTerminal(terminal => {
+        if (terminal == g_terminal) {
             g_terminal = null;
         }
     })

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -1,19 +1,29 @@
 import * as vscode from 'vscode';
+import * as rpc from 'vscode-jsonrpc';
 import * as path from 'path';
 import * as net from 'net';
 import * as os from 'os';
+import * as vslc from 'vscode-languageclient';
+import * as settings from './settings';
+
+let g_context: vscode.ExtensionContext = null;
+let g_settings: settings.ISettings = null;
+let g_languageClient: vslc.LanguageClient = null;
+
+let g_terminal: vscode.Terminal = null
+
+let g_plots: Array<string> = new Array<string>();
+let g_currentPlotIndex: number = 0;
 
 export class PlotPaneDocumentContentProvider implements vscode.TextDocumentContentProvider {
     private _onDidChange = new vscode.EventEmitter<vscode.Uri>();
-    public plots: Array<string> = new Array<string>();
-    public currentPlotIndex: number = 0;
 
     public provideTextDocumentContent(uri: vscode.Uri): string {
-        if(this.plots.length==0) {
+        if(g_plots.length==0) {
             return '<html></html>';
         }
         else {
-            return this.plots[this.currentPlotIndex];
+            return g_plots[g_currentPlotIndex];
         }
     }
 
@@ -24,48 +34,50 @@ export class PlotPaneDocumentContentProvider implements vscode.TextDocumentConte
     public update() {
         this._onDidChange.fire(vscode.Uri.parse('jlplotpane://nothing.html'));
     }
+}
 
-    public showPlotPane() {
-        let uri = vscode.Uri.parse('jlplotpane://nothing.html');
-        vscode.commands.executeCommand('vscode.previewHtml', uri, undefined, "julia Plot Pane");
+let g_plotPaneProvider: PlotPaneDocumentContentProvider = null;
+
+export function showPlotPane() {
+    let uri = vscode.Uri.parse('jlplotpane://nothing.html');
+    vscode.commands.executeCommand('vscode.previewHtml', uri, undefined, "julia Plot Pane");
+}
+
+export function plotPanePrev() {
+    if(g_currentPlotIndex>0) {
+        g_currentPlotIndex = g_currentPlotIndex - 1;
+        g_plotPaneProvider.update();
     }
-    
-    public plotPanePrev() {
-        if(this.currentPlotIndex>0) {
-            this.currentPlotIndex = this.currentPlotIndex - 1;
-            this.update();
-        }
+}
+
+export function plotPaneNext() {
+    if(g_currentPlotIndex<g_plots.length-1) {
+        g_currentPlotIndex = g_currentPlotIndex + 1;
+        g_plotPaneProvider.update();
     }
-    
-    public plotPaneNext() {
-        if(this.currentPlotIndex<this.plots.length-1) {
-            this.currentPlotIndex = this.currentPlotIndex + 1;
-            this.update();
-        }
+}
+
+export function plotPaneFirst() {
+    if(g_plots.length>0) {
+        g_currentPlotIndex = 0;
+        g_plotPaneProvider.update();
     }
-    
-    public plotPaneFirst() {
-        if(this.plots.length>0) {
-            this.currentPlotIndex = 0;
-            this.update();
-        }
+}
+
+export function plotPaneLast() {
+    if(g_plots.length>0) {
+        g_currentPlotIndex = g_plots.length - 1;
+        g_plotPaneProvider.update();
     }
-    
-    public plotPaneLast() {
-        if(this.plots.length>0) {
-            this.currentPlotIndex = this.plots.length - 1;
-            this.update();
+}
+
+export function plotPaneDel() {
+    if(g_plots.length>0) {
+        g_plots.splice(g_currentPlotIndex,1);
+        if(g_currentPlotIndex>g_plots.length-1) {
+            g_currentPlotIndex = g_plots.length - 1;
         }
-    }
-    
-    public plotPaneDel() {
-        if(this.plots.length>0) {
-            this.plots.splice(this.currentPlotIndex,1);
-            if(this.currentPlotIndex>this.plots.length-1) {
-                this.currentPlotIndex = this.plots.length - 1;
-            }
-            this.update();
-        }
+        g_plotPaneProvider.update();
     }
 }
 
@@ -79,22 +91,12 @@ function generatePipeName(pid: string, name:string) {
 }
 
 export class REPLHandler implements vscode.TreeDataProvider<string> {
-    public terminal: vscode.Terminal = null
-    private extensionPath
-    private juliaExecutable
-    public plotPaneProvider: PlotPaneDocumentContentProvider = new PlotPaneDocumentContentProvider();
     private variables:string = ''
     private _onDidChangeTreeData: vscode.EventEmitter<string | undefined> = new vscode.EventEmitter<string | undefined>();
     readonly onDidChangeTreeData: vscode.Event<string | undefined> = this._onDidChangeTreeData.event;
-    
+
     refresh(): void {
         this._onDidChangeTreeData.fire();
-    }
-
-
-    constructor(extensionPath, juliaExecutable) {
-        this.extensionPath = extensionPath
-        this.juliaExecutable = juliaExecutable
     }
 
     getChildren(node?: string) {
@@ -102,7 +104,7 @@ export class REPLHandler implements vscode.TreeDataProvider<string> {
             return [node]
         }
         else {
-            if (this.terminal) {
+            if (g_terminal) {
                 return this.variables.split(',').slice(1)
             }
             else {
@@ -115,162 +117,229 @@ export class REPLHandler implements vscode.TreeDataProvider<string> {
         let treeItem: vscode.TreeItem = new vscode.TreeItem(node)
         return treeItem;
     }
+}
 
-    public startREPL() {
-        if (this.terminal==null) {
-            this.startREPLConn()
-            this.startPlotDisplayServer()
-            let args = path.join(this.extensionPath, 'scripts', 'terminalserver', 'terminalserver.jl')
-            this.terminal = vscode.window.createTerminal("julia", this.juliaExecutable, ['-q', '-i', args, process.pid.toString()]);
-        }
-        this.terminal.show();
+function startREPL() {
+    if (g_terminal==null) {
+        startREPLConn()
+        startPlotDisplayServer()
+        let args = path.join(g_context.extensionPath, 'scripts', 'terminalserver', 'terminalserver.jl')
+        g_terminal = vscode.window.createTerminal("julia", g_settings.juliaExePath, ['-q', '-i', args, process.pid.toString()]);
     }
+    g_terminal.show();
+}
 
-    private startREPLConn() {
-        let PIPE_PATH = generatePipeName(process.pid.toString(), 'vscode-language-julia-fromrepl');
-        let replhandler = this
-    
-        var server = net.createServer(function(stream) {
-            let accumulatingBuffer = new Buffer(0);
-    
-            stream.on('data', async function(c) {
-                accumulatingBuffer = Buffer.concat([accumulatingBuffer, Buffer.from(c)]);
-                let bufferResult = accumulatingBuffer.toString()
-                let replResponse = accumulatingBuffer.toString().split(",")
-    
-                if (replResponse[0] == "repl/returnModules") 
-                {
-                    let result = await vscode.window.showQuickPick(replResponse.slice(1), {placeHolder: 'Switch to Module...'})
-                    if (result!=undefined) {
-                        replhandler.sendMessage('repl/changeModule',result)
-                    }
+function startREPLConn() {
+    let PIPE_PATH = generatePipeName(process.pid.toString(), 'vscode-language-julia-fromrepl');
+    let replhandler = this
+
+    var server = net.createServer(function(stream) {
+        let accumulatingBuffer = new Buffer(0);
+
+        stream.on('data', async function(c) {
+            accumulatingBuffer = Buffer.concat([accumulatingBuffer, Buffer.from(c)]);
+            let bufferResult = accumulatingBuffer.toString()
+            let replResponse = accumulatingBuffer.toString().split(",")
+
+            if (replResponse[0] == "repl/returnModules")
+            {
+                let result = await vscode.window.showQuickPick(replResponse.slice(1), {placeHolder: 'Switch to Module...'})
+                if (result!=undefined) {
+                    replhandler.sendMessage('repl/changeModule',result)
                 }
-                if (replResponse[0] == "repl/variables") 
-                {
-                    replhandler.variables = bufferResult
-                    replhandler.refresh()
-                }
-            });
-        });
-    
-        server.on('close',function(){
-            console.log('Server: on close');
-        })
-    
-        server.listen(PIPE_PATH, function(){
-            console.log('Server: on listening');
-        })
-    }
-
-    startPlotDisplayServer() {
-        let PIPE_PATH = generatePipeName(process.pid.toString(), 'vscode-language-julia-terminal');
-
-        let plotPaneProvider = this.plotPaneProvider
-    
-        var server = net.createServer(function(stream) {
-            let accumulatingBuffer = new Buffer(0);
-    
-            stream.on('data', function(c) {
-                accumulatingBuffer = Buffer.concat([accumulatingBuffer, Buffer.from(c)]);
-                let s = accumulatingBuffer.toString();
-                let index_of_sep_1 = s.indexOf(":");
-                let index_of_sep_2 = s.indexOf(";");
-    
-                if(index_of_sep_2>-1) {
-                    let mime_type = s.substring(0,index_of_sep_1);
-                    let msg_len_as_string = s.substring(index_of_sep_1+1,index_of_sep_2);
-                    let msg_len = parseInt(msg_len_as_string);
-                    if(accumulatingBuffer.length>=mime_type.length+msg_len_as_string.length+2+msg_len) {
-                        let actual_image = s.substring(index_of_sep_2+1);
-                        if(accumulatingBuffer.length > mime_type.length+msg_len_as_string.length+2+msg_len) {
-                            accumulatingBuffer = Buffer.from(accumulatingBuffer.slice(mime_type.length+msg_len_as_string.length+2+msg_len + 1));
-                        }
-                        else {
-                            accumulatingBuffer = new Buffer(0);
-                        }
-    
-                        if(mime_type=='image/svg+xml') {
-                            plotPaneProvider.currentPlotIndex = plotPaneProvider.plots.push(actual_image)-1;
-                        }
-                        else if(mime_type=='image/png') {
-                            let plotPaneContent = '<html><img src="data:image/png;base64,' + actual_image + '" /></html>';
-                            plotPaneProvider.currentPlotIndex = plotPaneProvider.plots.push(plotPaneContent)-1;
-                        }
-                        else {
-                            throw new Error();
-                        }
-                        
-                        let uri = vscode.Uri.parse('jlplotpane://nothing.html');
-                        plotPaneProvider.update();
-                        vscode.commands.executeCommand('vscode.previewHtml', uri, undefined, "julia Plot Pane");
-                    }
-                }
-            });
-        });
-    
-        server.on('close',function(){
-            console.log('Server: on close');
-        })
-    
-        server.listen(PIPE_PATH,function(){
-            console.log('Server: on listening');
-        })
-    }
-
-    public executeCode(text) {
-        if(!text.endsWith("\n")) {
-            text = text + '\n';
-        }
-    
-        this.startREPL();
-        this.terminal.show(true);
-        var lines = text.split(/\r?\n/);
-        lines = lines.filter(line=>line!='');
-        text = lines.join('\n');
-        this.terminal.sendText(text + '\n', false);
-    }
-
-    public executeSelection() {
-        var editor = vscode.window.activeTextEditor;
-        if(!editor) {
-            return;
-        }
-    
-        var selection = editor.selection;
-
-        var text = selection.isEmpty ? editor.document.lineAt(selection.start.line).text : editor.document.getText(selection);
-    
-        // If no text was selected, try to move the cursor to the end of the next line
-        if (selection.isEmpty) {
-            for (var line = selection.start.line+1; line < editor.document.lineCount; line++) {
-            if (!editor.document.lineAt(line).isEmptyOrWhitespace) {
-                var newPos = selection.active.with(line, editor.document.lineAt(line).range.end.character);
-                var newSel = new vscode.Selection(newPos, newPos);
-                editor.selection = newSel;
-                break;
             }
+            if (replResponse[0] == "repl/variables")
+            {
+                replhandler.variables = bufferResult
+                replhandler.refresh()
             }
-        }
-        this.executeCode(text)
-        editor.show()
+        });
+    });
+
+    server.on('close',function(){
+        console.log('Server: on close');
+    })
+
+    server.listen(PIPE_PATH, function(){
+        console.log('Server: on listening');
+    })
+}
+
+function startPlotDisplayServer() {
+    let PIPE_PATH = generatePipeName(process.pid.toString(), 'vscode-language-julia-terminal');
+
+    var server = net.createServer(function(stream) {
+        let accumulatingBuffer = new Buffer(0);
+
+        stream.on('data', function(c) {
+            accumulatingBuffer = Buffer.concat([accumulatingBuffer, Buffer.from(c)]);
+            let s = accumulatingBuffer.toString();
+            let index_of_sep_1 = s.indexOf(":");
+            let index_of_sep_2 = s.indexOf(";");
+
+            if(index_of_sep_2>-1) {
+                let mime_type = s.substring(0,index_of_sep_1);
+                let msg_len_as_string = s.substring(index_of_sep_1+1,index_of_sep_2);
+                let msg_len = parseInt(msg_len_as_string);
+                if(accumulatingBuffer.length>=mime_type.length+msg_len_as_string.length+2+msg_len) {
+                    let actual_image = s.substring(index_of_sep_2+1);
+                    if(accumulatingBuffer.length > mime_type.length+msg_len_as_string.length+2+msg_len) {
+                        accumulatingBuffer = Buffer.from(accumulatingBuffer.slice(mime_type.length+msg_len_as_string.length+2+msg_len + 1));
+                    }
+                    else {
+                        accumulatingBuffer = new Buffer(0);
+                    }
+
+                    if(mime_type=='image/svg+xml') {
+                        g_currentPlotIndex = g_plots.push(actual_image)-1;
+                    }
+                    else if(mime_type=='image/png') {
+                        let plotPaneContent = '<html><img src="data:image/png;base64,' + actual_image + '" /></html>';
+                        g_currentPlotIndex = g_plots.push(plotPaneContent)-1;
+                    }
+                    else {
+                        throw new Error();
+                    }
+
+                    let uri = vscode.Uri.parse('jlplotpane://nothing.html');
+                    g_plotPaneProvider.update();
+                    vscode.commands.executeCommand('vscode.previewHtml', uri, undefined, "julia Plot Pane");
+                }
+            }
+        });
+    });
+
+    server.on('close',function(){
+        console.log('Server: on close');
+    })
+
+    server.listen(PIPE_PATH,function(){
+        console.log('Server: on listening');
+    })
+}
+
+function executeCode(text) {
+    if(!text.endsWith("\n")) {
+        text = text + '\n';
     }
 
-    public executeFile() {
+    startREPL();
+    g_terminal.show(true);
+    var lines = text.split(/\r?\n/);
+    lines = lines.filter(line=>line!='');
+    text = lines.join('\n');
+    g_terminal.sendText(text + '\n', false);
+}
+
+function executeSelection() {
+    var editor = vscode.window.activeTextEditor;
+    if(!editor) {
+        return;
+    }
+
+    var selection = editor.selection;
+
+    var text = selection.isEmpty ? editor.document.lineAt(selection.start.line).text : editor.document.getText(selection);
+
+    // If no text was selected, try to move the cursor to the end of the next line
+    if (selection.isEmpty) {
+        for (var line = selection.start.line+1; line < editor.document.lineCount; line++) {
+        if (!editor.document.lineAt(line).isEmptyOrWhitespace) {
+            var newPos = selection.active.with(line, editor.document.lineAt(line).range.end.character);
+            var newSel = new vscode.Selection(newPos, newPos);
+            editor.selection = newSel;
+            break;
+        }
+        }
+    }
+    executeCode(text)
+    editor.show()
+}
+
+function executeFile() {
+    var editor = vscode.window.activeTextEditor;
+    if(!editor) {
+        return;
+    }
+    sendMessage('repl/include', editor.document.fileName)
+}
+
+function executeJuliaBlockInRepl() {
+    if (g_languageClient == null) {
+        vscode.window.showErrorMessage('Error: Language server is not running.');
+    }
+    else {
         var editor = vscode.window.activeTextEditor;
-        if(!editor) {
-            return;
-        }
-        this.sendMessage('repl/include', editor.document.fileName)
-    }
-
-    public sendMessage(cmd, msg: string) {
-        this.startREPL()
-        let sock = generatePipeName(process.pid.toString(), 'vscode-language-julia-torepl')
-    
-        let conn = net.connect(sock)
-        conn.write(cmd + '\n' + msg + "\nrepl/endMessage")
-        conn.on('error', () => {vscode.window.showErrorMessage("REPL is not open")})
+        let params: TextDocumentPositionParams = { textDocument: vslc.TextDocumentIdentifier.create(editor.document.uri.toString()), position: new vscode.Position(editor.selection.start.line, editor.selection.start.character) }
+        g_languageClient.sendRequest('julia/getCurrentBlockText', params).then((text) => {
+            executeCode(text)
+            vscode.window.showTextDocument(vscode.window.activeTextEditor.document)
+        })
     }
 }
 
+function sendMessage(cmd, msg: string) {
+    startREPL()
+    let sock = generatePipeName(process.pid.toString(), 'vscode-language-julia-torepl')
 
+    let conn = net.connect(sock)
+    conn.write(cmd + '\n' + msg + "\nrepl/endMessage")
+    conn.on('error', () => {vscode.window.showErrorMessage("REPL is not open")})
+}
+
+export interface TextDocumentPositionParams {
+    textDocument: vslc.TextDocumentIdentifier
+    position: vscode.Position
+}
+
+let getBlockText = new rpc.RequestType<TextDocumentPositionParams, void,void,void>('julia/getCurrentBlockText')
+
+export function activate(context: vscode.ExtensionContext, settings: settings.ISettings) {
+    g_context = context;
+    g_settings = settings;
+
+    g_plotPaneProvider = new PlotPaneDocumentContentProvider();
+    context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider('jlplotpane', g_plotPaneProvider));
+
+    context.subscriptions.push(vscode.window.registerTreeDataProvider('REPLVariables', new REPLHandler()));
+
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.startREPL', startREPL));
+
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.executeJuliaCodeInREPL', executeSelection));
+
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.executeJuliaFileInREPL', executeFile));
+
+    // TODO DA I don't understand what this does
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.change-repl-module', () => {
+        sendMessage('repl/getAvailableModules', '')
+        vscode.window.showTextDocument(vscode.window.activeTextEditor.document)
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.executeJuliaBlockInREPL', executeJuliaBlockInRepl));
+
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.show-plotpane', showPlotPane));
+
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.plotpane-previous', plotPanePrev));
+
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.plotpane-next', plotPaneNext));
+
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.plotpane-first', plotPaneFirst));
+
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.plotpane-last', plotPaneLast));
+
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.plotpane-delete', plotPaneDel));
+
+    vscode.window.onDidCloseTerminal(terminal=>{
+        if (terminal==g_terminal) {
+            g_terminal = null;
+        }
+    })
+}
+
+export function onDidChangeConfiguration(newSettings: settings.ISettings) {
+
+}
+
+export function onNewLanguageClient(newLanguageClient: vslc.LanguageClient) {
+    g_languageClient = newLanguageClient;
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,13 @@
+import * as vscode from 'vscode';
+
+export interface ISettings {
+    juliaExePath?: string;
+}
+
+export function loadSettings(): ISettings {
+    let section = vscode.workspace.getConfiguration('julia');
+
+    return {
+        juliaExePath: section ? section.get<string>('executablePath', null) : null
+    };
+}

--- a/src/smallcommands.ts
+++ b/src/smallcommands.ts
@@ -1,0 +1,117 @@
+import * as vscode from 'vscode';
+import * as settings from './settings'
+import * as vslc from 'vscode-languageclient';
+
+let g_context: vscode.ExtensionContext = null;
+let g_settings: settings.ISettings = null;
+let g_languageClient: vslc.LanguageClient = null;
+
+function toggleLinter() {
+    let cval = vscode.workspace.getConfiguration('julia').get('runlinter', false)
+    vscode.workspace.getConfiguration('julia').update('runlinter', !cval, true)
+}
+
+function applyTextEdit(we) {
+    let wse = new vscode.WorkspaceEdit()
+    for (let edit of we.documentChanges[0].edits) {
+        wse.replace(we.documentChanges[0].textDocument.uri, new vscode.Range(edit.range.start.line, edit.range.start.character, edit.range.end.line, edit.range.end.character), edit.newText)
+    }
+    vscode.workspace.applyEdit(wse)
+}
+
+function lintPackage() {
+    if (g_languageClient == null) {
+        vscode.window.showErrorMessage('Error: package linting only works with a running julia language server.');
+    }
+    else {
+        try {
+            g_languageClient.sendRequest("julia/lint-package");
+        }
+        catch (ex) {
+            if (ex.message == "Language client is not ready yet") {
+                vscode.window.showErrorMessage('Error: package linting only works with a running julia language server.');
+            }
+            else {
+                throw ex;
+            }
+        }
+    }
+}
+
+function reloadModules() {
+    if (g_languageClient == null) {
+        vscode.window.showErrorMessage('Error: Language server is not yet running.');
+    }
+    else {
+        try {
+            g_languageClient.sendRequest("julia/reload-modules");
+        }
+        catch (ex) {
+            if (ex.message == "Language client is not ready yet") {
+                vscode.window.showErrorMessage('Error: Language server is not yet running.');
+            }
+            else {
+                throw ex;
+            }
+        }
+    }
+}
+
+function toggleServerLogs() {
+    if (g_languageClient == null) {
+        vscode.window.showErrorMessage('Error: Lanuage server is not yet running.');
+    }
+    else {
+        try {
+            g_languageClient.sendRequest("julia/toggle-log");
+        }
+        catch (ex) {
+            if (ex.message == "Language client is not ready yet") {
+                vscode.window.showErrorMessage('Error: server is not running.');
+            }
+            else {
+                throw ex;
+            }
+        }
+    }
+}
+
+function toggleFileLint(arg) {
+    if (g_languageClient == null) {
+        vscode.window.showErrorMessage('Error: Lanuage server is not yet running.');
+    }
+    else {
+        try {
+            g_languageClient.sendRequest("julia/toggleFileLint", arg);
+        }
+        catch (ex) {
+            5
+            if (ex.message == "Language client is not ready yet") {
+                vscode.window.showErrorMessage('Error: server is not running.');
+            }
+            else {
+                throw ex;
+            }
+        }
+    }
+}
+
+export function activate(context: vscode.ExtensionContext, settings: settings.ISettings) {
+    g_context = context;
+    g_settings = settings;
+
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.applytextedit', applyTextEdit));
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.lint-package', lintPackage));
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.toggleLinter', toggleLinter));
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.reload-modules', reloadModules));
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.toggle-log', toggleServerLogs));
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.toggle-file-lint', toggleFileLint));
+}
+
+export function onDidChangeConfiguration(newSettings: settings.ISettings) {
+
+}
+
+export function onNewLanguageClient(newLanguageClient: vslc.LanguageClient) {
+    g_languageClient = newLanguageClient;
+}

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -1,0 +1,82 @@
+import * as vscode from 'vscode';
+import * as vslc from 'vscode-languageclient';
+import * as fs from 'async-file';
+import * as path from 'path'
+import * as settings from './settings'
+
+let g_context: vscode.ExtensionContext = null;
+let g_settings: settings.ISettings = null;
+let g_languageClient: vslc.LanguageClient = null;
+
+let taskProvider: vscode.Disposable | undefined;
+
+async function getJuliaTasks(): Promise<vscode.Task[]> {
+    let workspaceRoot = vscode.workspace.rootPath;
+
+    let emptyTasks: vscode.Task[] = [];
+
+    if (!workspaceRoot) {
+        return emptyTasks;
+    }
+
+    try {
+        const result: vscode.Task[] = [];
+
+        if (await fs.exists(path.join(workspaceRoot, 'test', 'runtests.jl'))) {
+            let testTask = new vscode.Task({ type: 'julia', command: 'test' }, `Run tests`, 'julia', new vscode.ProcessExecution(g_settings.juliaExePath, ['--color=yes', '-e', 'Pkg.test(Base.ARGS[1])', vscode.workspace.rootPath]), "");
+            testTask.group = vscode.TaskGroup.Test;
+            testTask.presentationOptions = { echo: false };
+            result.push(testTask);
+        }
+
+        if (await fs.exists(path.join(workspaceRoot, 'deps', 'build.jl'))) {
+            let splitted_path = vscode.workspace.rootPath.split(path.sep);
+            let package_name = splitted_path[splitted_path.length-1];
+            let buildTask = new vscode.Task({ type: 'julia', command: 'build'}, `Run build`, 'julia', new vscode.ProcessExecution(g_settings.juliaExePath, ['--color=yes', '-e', 'Pkg.build(Base.ARGS[1])', package_name]), "");
+            buildTask.group = vscode.TaskGroup.Build;
+            buildTask.presentationOptions = { echo: false };
+            result.push(buildTask);
+        }
+
+        if (await fs.exists(path.join(workspaceRoot, 'benchmark', 'benchmarks.jl'))) {
+            let splitted_path = vscode.workspace.rootPath.split(path.sep);
+            let package_name = splitted_path[splitted_path.length-1];
+            let benchmarkTask = new vscode.Task({ type: 'julia', command: 'benchmark'}, `Run benchmark`, 'julia', new vscode.ProcessExecution(g_settings.juliaExePath, ['--color=yes', '-e', 'using PkgBenchmark; benchmarkpkg(Base.ARGS[1], promptsave=false, promptoverwrite=false)', package_name]), "");
+            benchmarkTask.presentationOptions = { echo: false };
+            result.push(benchmarkTask);
+        }
+
+        if (await fs.exists(path.join(workspaceRoot, 'docs', 'make.jl'))) {
+            let buildTask = new vscode.Task({ type: 'julia', command: 'docbuild'}, `Build documentation`, 'julia', new vscode.ProcessExecution(g_settings.juliaExePath, ['--color=yes', '-e', 'include(Base.ARGS[1])', path.join(workspaceRoot, 'docs', 'make.jl')]), "");
+            buildTask.group = vscode.TaskGroup.Build;
+            buildTask.presentationOptions = { echo: false };
+            result.push(buildTask);
+        }
+
+        return Promise.resolve(result);
+    } catch (e) {
+        return Promise.resolve(emptyTasks);
+    }
+}
+
+export function activate(context: vscode.ExtensionContext, settings: settings.ISettings) {
+    g_context = context;
+    g_settings = settings;
+
+    taskProvider = vscode.workspace.registerTaskProvider('julia', {
+        provideTasks: () => {
+            return getJuliaTasks();
+        },
+        resolveTask(_task: vscode.Task): vscode.Task | undefined {
+            return undefined;
+        }
+    });
+}
+
+export function onDidChangeConfiguration(newSettings: settings.ISettings) {
+
+}
+
+export function onNewLanguageClient(newLanguageClient: vslc.LanguageClient) {
+    g_languageClient = newLanguageClient;
+}

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -31,8 +31,8 @@ async function getJuliaTasks(): Promise<vscode.Task[]> {
 
         if (await fs.exists(path.join(workspaceRoot, 'deps', 'build.jl'))) {
             let splitted_path = vscode.workspace.rootPath.split(path.sep);
-            let package_name = splitted_path[splitted_path.length-1];
-            let buildTask = new vscode.Task({ type: 'julia', command: 'build'}, `Run build`, 'julia', new vscode.ProcessExecution(g_settings.juliaExePath, ['--color=yes', '-e', 'Pkg.build(Base.ARGS[1])', package_name]), "");
+            let package_name = splitted_path[splitted_path.length - 1];
+            let buildTask = new vscode.Task({ type: 'julia', command: 'build' }, `Run build`, 'julia', new vscode.ProcessExecution(g_settings.juliaExePath, ['--color=yes', '-e', 'Pkg.build(Base.ARGS[1])', package_name]), "");
             buildTask.group = vscode.TaskGroup.Build;
             buildTask.presentationOptions = { echo: false };
             result.push(buildTask);
@@ -40,14 +40,14 @@ async function getJuliaTasks(): Promise<vscode.Task[]> {
 
         if (await fs.exists(path.join(workspaceRoot, 'benchmark', 'benchmarks.jl'))) {
             let splitted_path = vscode.workspace.rootPath.split(path.sep);
-            let package_name = splitted_path[splitted_path.length-1];
-            let benchmarkTask = new vscode.Task({ type: 'julia', command: 'benchmark'}, `Run benchmark`, 'julia', new vscode.ProcessExecution(g_settings.juliaExePath, ['--color=yes', '-e', 'using PkgBenchmark; benchmarkpkg(Base.ARGS[1], promptsave=false, promptoverwrite=false)', package_name]), "");
+            let package_name = splitted_path[splitted_path.length - 1];
+            let benchmarkTask = new vscode.Task({ type: 'julia', command: 'benchmark' }, `Run benchmark`, 'julia', new vscode.ProcessExecution(g_settings.juliaExePath, ['--color=yes', '-e', 'using PkgBenchmark; benchmarkpkg(Base.ARGS[1], promptsave=false, promptoverwrite=false)', package_name]), "");
             benchmarkTask.presentationOptions = { echo: false };
             result.push(benchmarkTask);
         }
 
         if (await fs.exists(path.join(workspaceRoot, 'docs', 'make.jl'))) {
-            let buildTask = new vscode.Task({ type: 'julia', command: 'docbuild'}, `Build documentation`, 'julia', new vscode.ProcessExecution(g_settings.juliaExePath, ['--color=yes', '-e', 'include(Base.ARGS[1])', path.join(workspaceRoot, 'docs', 'make.jl')]), "");
+            let buildTask = new vscode.Task({ type: 'julia', command: 'docbuild' }, `Build documentation`, 'julia', new vscode.ProcessExecution(g_settings.juliaExePath, ['--color=yes', '-e', 'include(Base.ARGS[1])', path.join(workspaceRoot, 'docs', 'make.jl')]), "");
             buildTask.group = vscode.TaskGroup.Build;
             buildTask.presentationOptions = { echo: false };
             result.push(buildTask);

--- a/src/weave.ts
+++ b/src/weave.ts
@@ -1,27 +1,28 @@
 import * as vscode from 'vscode';
+import * as vslc from 'vscode-languageclient';
 import { spawn, ChildProcess } from 'child_process';
 import * as path from 'path';
 import * as fs from 'async-file';
+import * as settings from './settings'
 
 var tempfs = require('promised-temp').track();
 var kill = require('async-child-process').kill;
 
-export class WeaveDocumentContentProvider implements vscode.TextDocumentContentProvider {
-    private juliaExecutable
-    private extensionPath
-    private _onDidChange = new vscode.EventEmitter<vscode.Uri>();
-    private lastWeaveContent: string = null;
-    private weaveOutputChannel: vscode.OutputChannel = null;
-    private weaveChildProcess: ChildProcess = null;
-    private weaveNextChildProcess: ChildProcess = null;
+let g_context: vscode.ExtensionContext = null;
+let g_settings: settings.ISettings = null;
+let g_languageClient: vslc.LanguageClient = null;
 
-    constructor(extensionPath, juliaExecutable) {
-        this.extensionPath = extensionPath
-        this.juliaExecutable = juliaExecutable
-    }
+let g_lastWeaveContent: string = null;
+let g_weaveOutputChannel: vscode.OutputChannel = null;
+let g_weaveChildProcess: ChildProcess = null;
+let g_weaveNextChildProcess: ChildProcess = null;
+
+
+export class WeaveDocumentContentProvider implements vscode.TextDocumentContentProvider {
+    private _onDidChange = new vscode.EventEmitter<vscode.Uri>();
 
     public provideTextDocumentContent(uri: vscode.Uri): string {
-        return this.lastWeaveContent;
+        return g_lastWeaveContent;
     }
 
     get onDidChange(): vscode.Event<vscode.Uri> {
@@ -31,137 +32,162 @@ export class WeaveDocumentContentProvider implements vscode.TextDocumentContentP
     public update() {
         this._onDidChange.fire(vscode.Uri.parse('jlweave://nothing.html'));
     }
-    
-    async weave_core(column, selected_format:string=undefined) {
-        let parsed_filename = path.parse(vscode.window.activeTextEditor.document.fileName);
-        let weaveProvider = this
-    
-        let source_filename: string;
-        let output_filename: string;
-        if (selected_format===undefined) {
-            let temporary_dirname = await tempfs.mkdir("julia-vscode-weave");
-    
-            source_filename = path.join(temporary_dirname, 'source-file.jmd')
-    
-            await fs.writeFile(source_filename, vscode.window.activeTextEditor.document.getText(), 'utf8');
-        
-            output_filename = path.join(temporary_dirname, 'output-file.html');
-        }
-        else {
-            source_filename = vscode.window.activeTextEditor.document.fileName;
-            output_filename = '';
-        }
-    
-        if (this.weaveOutputChannel == null) {
-            this.weaveOutputChannel = vscode.window.createOutputChannel("julia Weave");
-        }
-        this.weaveOutputChannel.clear();
-        this.weaveOutputChannel.show(true);
-    
-        if (this.weaveChildProcess != null) {
-            try {
-                await kill(this.weaveChildProcess);
-            }
-            catch (e) {
-            }
-        }
-    
-        if (this.weaveNextChildProcess == null) {
-            this.weaveNextChildProcess = spawn(this.juliaExecutable, [path.join(this.extensionPath, 'scripts', 'weave', 'run_weave.jl')]);
-        }
-        this.weaveChildProcess = this.weaveNextChildProcess;
-    
-        this.weaveChildProcess.stdin.write(source_filename + '\n');
-        this.weaveChildProcess.stdin.write(output_filename + '\n');
-        if (selected_format===undefined) {
-            this.weaveChildProcess.stdin.write('PREVIEW\n');
-        }
-        else {
-            this.weaveChildProcess.stdin.write(selected_format + '\n');
-        }
-    
-        weaveProvider.weaveNextChildProcess = spawn(this.juliaExecutable, [path.join(weaveProvider.extensionPath, 'scripts', 'weave', 'run_weave.jl')]);
-    
-        weaveProvider.weaveChildProcess.stdout.on('data', function (data) {
-            weaveProvider.weaveOutputChannel.append(String(data));
-        });
-        weaveProvider.weaveChildProcess.stderr.on('data', function (data) {
-            weaveProvider.weaveOutputChannel.append(String(data));
-        });
-        weaveProvider.weaveChildProcess.on('close', async function (code) {
-            weaveProvider.weaveChildProcess = null;
-    
-            if (code == 0) {
-                weaveProvider.weaveOutputChannel.hide();
-    
-                if (selected_format===undefined) {
-                    weaveProvider.lastWeaveContent = await fs.readFile(output_filename, "utf8")
-    
-                    let uri = vscode.Uri.parse('jlweave://nothing.html');
-                    weaveProvider.update();
-                    let success = await vscode.commands.executeCommand('vscode.previewHtml', uri, column, "julia Weave Preview");
-                }
-            }
-            else {
-                vscode.window.showErrorMessage("Error during weaving.");
-            }
-    
-        });
+}
+
+let g_weaveProvider: WeaveDocumentContentProvider = null;
+
+async function weave_core(column, selected_format:string=undefined) {
+    let parsed_filename = path.parse(vscode.window.activeTextEditor.document.fileName);
+    let weaveProvider = this
+
+    let source_filename: string;
+    let output_filename: string;
+    if (selected_format===undefined) {
+        let temporary_dirname = await tempfs.mkdir("julia-vscode-weave");
+
+        source_filename = path.join(temporary_dirname, 'source-file.jmd')
+
+        await fs.writeFile(source_filename, vscode.window.activeTextEditor.document.getText(), 'utf8');
+
+        output_filename = path.join(temporary_dirname, 'output-file.html');
     }
-    
-    async open_preview() {
-        if (vscode.window.activeTextEditor === undefined) {
-            vscode.window.showErrorMessage('Please open a document before you execute the weave command.');
+    else {
+        source_filename = vscode.window.activeTextEditor.document.fileName;
+        output_filename = '';
+    }
+
+    if (g_weaveOutputChannel == null) {
+        g_weaveOutputChannel = vscode.window.createOutputChannel("julia Weave");
+    }
+    g_weaveOutputChannel.clear();
+    g_weaveOutputChannel.show(true);
+
+    if (g_weaveChildProcess != null) {
+        try {
+            await kill(g_weaveChildProcess);
         }
-        else if (vscode.window.activeTextEditor.document.languageId!='juliamarkdown') {
-            vscode.window.showErrorMessage('Only julia Markdown (.jmd) files can be weaved.');
-        }
-        else {
-            this.weave_core(vscode.ViewColumn.One);
+        catch (e) {
         }
     }
-    
-    async open_preview_side() {
-        if (vscode.window.activeTextEditor === undefined) {
-            vscode.window.showErrorMessage('Please open a document before you execute the weave command.');
-        }
-        else if (vscode.window.activeTextEditor.document.languageId!='juliamarkdown') {
-            vscode.window.showErrorMessage('Only julia Markdown (.jmd) files can be weaved.');
-        }
-        else {
-            this.weave_core(vscode.ViewColumn.Two);
-        }
+
+    if (g_weaveNextChildProcess == null) {
+        g_weaveNextChildProcess = spawn(g_settings.juliaExePath, [path.join(g_context.extensionPath, 'scripts', 'weave', 'run_weave.jl')]);
     }
-    
-    async save() {
-        if (vscode.window.activeTextEditor === undefined) {
-            vscode.window.showErrorMessage('Please open a document before you execute the weave command.');
-        }
-        else if (vscode.window.activeTextEditor.document.languageId!='juliamarkdown') {
-            vscode.window.showErrorMessage('Only julia Markdown (.jmd) files can be weaved.');
-        }
-        else if (vscode.window.activeTextEditor.document.isDirty || vscode.window.activeTextEditor.document.isUntitled) {
-            vscode.window.showErrorMessage('Please save the file before weaving.');
-        }
-        else {
-            let formats = ['github: Github markdown',
-                'md2tex: Julia markdown to latex',
-                'pandoc2html: Markdown to HTML (requires Pandoc)',
-                'pandoc: Pandoc markdown',
-                'pandoc2pdf: Pandoc markdown',
-                'tex: Latex with custom code environments',
-                'texminted: Latex using minted for highlighting',
-                'md2html: Julia markdown to html',
-                'rst: reStructuredText and Sphinx',
-                'multimarkdown: MultiMarkdown',
-                'md2pdf: Julia markdown to latex',
-                'asciidoc: AsciiDoc'];
-            let result_format = await vscode.window.showQuickPick(formats, {placeHolder: 'Select output format'});
-            if (result_format!=undefined) {
-                let index = result_format.indexOf(':');
-                let selected_format = result_format.substring(0,index);
-                this.weave_core(vscode.ViewColumn.One, selected_format);
+    g_weaveChildProcess = g_weaveNextChildProcess;
+
+    g_weaveChildProcess.stdin.write(source_filename + '\n');
+    g_weaveChildProcess.stdin.write(output_filename + '\n');
+    if (selected_format===undefined) {
+        g_weaveChildProcess.stdin.write('PREVIEW\n');
+    }
+    else {
+        g_weaveChildProcess.stdin.write(selected_format + '\n');
+    }
+
+    weaveProvider.weaveNextChildProcess = spawn(g_settings.juliaExePath, [path.join(weaveProvider.extensionPath, 'scripts', 'weave', 'run_weave.jl')]);
+
+    weaveProvider.weaveChildProcess.stdout.on('data', function (data) {
+        weaveProvider.weaveOutputChannel.append(String(data));
+    });
+    weaveProvider.weaveChildProcess.stderr.on('data', function (data) {
+        weaveProvider.weaveOutputChannel.append(String(data));
+    });
+    weaveProvider.weaveChildProcess.on('close', async function (code) {
+        weaveProvider.weaveChildProcess = null;
+
+        if (code == 0) {
+            weaveProvider.weaveOutputChannel.hide();
+
+            if (selected_format===undefined) {
+                weaveProvider.lastWeaveContent = await fs.readFile(output_filename, "utf8")
+
+                let uri = vscode.Uri.parse('jlweave://nothing.html');
+                weaveProvider.update();
+                let success = await vscode.commands.executeCommand('vscode.previewHtml', uri, column, "julia Weave Preview");
             }
         }
+        else {
+            vscode.window.showErrorMessage("Error during weaving.");
+        }
+
+    });
+}
+
+async function open_preview() {
+    if (vscode.window.activeTextEditor === undefined) {
+        vscode.window.showErrorMessage('Please open a document before you execute the weave command.');
     }
+    else if (vscode.window.activeTextEditor.document.languageId!='juliamarkdown') {
+        vscode.window.showErrorMessage('Only julia Markdown (.jmd) files can be weaved.');
+    }
+    else {
+        weave_core(vscode.ViewColumn.One);
+    }
+}
+
+async function open_preview_side() {
+    if (vscode.window.activeTextEditor === undefined) {
+        vscode.window.showErrorMessage('Please open a document before you execute the weave command.');
+    }
+    else if (vscode.window.activeTextEditor.document.languageId!='juliamarkdown') {
+        vscode.window.showErrorMessage('Only julia Markdown (.jmd) files can be weaved.');
+    }
+    else {
+        weave_core(vscode.ViewColumn.Two);
+    }
+}
+
+async function save() {
+    if (vscode.window.activeTextEditor === undefined) {
+        vscode.window.showErrorMessage('Please open a document before you execute the weave command.');
+    }
+    else if (vscode.window.activeTextEditor.document.languageId!='juliamarkdown') {
+        vscode.window.showErrorMessage('Only julia Markdown (.jmd) files can be weaved.');
+    }
+    else if (vscode.window.activeTextEditor.document.isDirty || vscode.window.activeTextEditor.document.isUntitled) {
+        vscode.window.showErrorMessage('Please save the file before weaving.');
+    }
+    else {
+        let formats = ['github: Github markdown',
+            'md2tex: Julia markdown to latex',
+            'pandoc2html: Markdown to HTML (requires Pandoc)',
+            'pandoc: Pandoc markdown',
+            'pandoc2pdf: Pandoc markdown',
+            'tex: Latex with custom code environments',
+            'texminted: Latex using minted for highlighting',
+            'md2html: Julia markdown to html',
+            'rst: reStructuredText and Sphinx',
+            'multimarkdown: MultiMarkdown',
+            'md2pdf: Julia markdown to latex',
+            'asciidoc: AsciiDoc'];
+        let result_format = await vscode.window.showQuickPick(formats, {placeHolder: 'Select output format'});
+        if (result_format!=undefined) {
+            let index = result_format.indexOf(':');
+            let selected_format = result_format.substring(0,index);
+            weave_core(vscode.ViewColumn.One, selected_format);
+        }
+    }
+}
+
+export function activate(context: vscode.ExtensionContext, settings: settings.ISettings) {
+    g_context = context;
+    g_settings = settings;
+
+    // Weave
+    g_weaveProvider = new WeaveDocumentContentProvider();
+    context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider('jlweave', g_weaveProvider));
+
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.weave-open-preview', open_preview));
+
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.weave-open-preview-side', open_preview_side));
+
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.weave-save', save));
+}
+
+export function onDidChangeConfiguration(newSettings: settings.ISettings) {
+
+}
+
+export function onNewLanguageClient(newLanguageClient: vslc.LanguageClient) {
+    g_languageClient = newLanguageClient;
 }

--- a/src/weave.ts
+++ b/src/weave.ts
@@ -36,13 +36,13 @@ export class WeaveDocumentContentProvider implements vscode.TextDocumentContentP
 
 let g_weaveProvider: WeaveDocumentContentProvider = null;
 
-async function weave_core(column, selected_format:string=undefined) {
+async function weave_core(column, selected_format: string = undefined) {
     let parsed_filename = path.parse(vscode.window.activeTextEditor.document.fileName);
     let weaveProvider = this
 
     let source_filename: string;
     let output_filename: string;
-    if (selected_format===undefined) {
+    if (selected_format === undefined) {
         let temporary_dirname = await tempfs.mkdir("julia-vscode-weave");
 
         source_filename = path.join(temporary_dirname, 'source-file.jmd')
@@ -77,7 +77,7 @@ async function weave_core(column, selected_format:string=undefined) {
 
     g_weaveChildProcess.stdin.write(source_filename + '\n');
     g_weaveChildProcess.stdin.write(output_filename + '\n');
-    if (selected_format===undefined) {
+    if (selected_format === undefined) {
         g_weaveChildProcess.stdin.write('PREVIEW\n');
     }
     else {
@@ -98,7 +98,7 @@ async function weave_core(column, selected_format:string=undefined) {
         if (code == 0) {
             weaveProvider.weaveOutputChannel.hide();
 
-            if (selected_format===undefined) {
+            if (selected_format === undefined) {
                 weaveProvider.lastWeaveContent = await fs.readFile(output_filename, "utf8")
 
                 let uri = vscode.Uri.parse('jlweave://nothing.html');
@@ -117,7 +117,7 @@ async function open_preview() {
     if (vscode.window.activeTextEditor === undefined) {
         vscode.window.showErrorMessage('Please open a document before you execute the weave command.');
     }
-    else if (vscode.window.activeTextEditor.document.languageId!='juliamarkdown') {
+    else if (vscode.window.activeTextEditor.document.languageId != 'juliamarkdown') {
         vscode.window.showErrorMessage('Only julia Markdown (.jmd) files can be weaved.');
     }
     else {
@@ -129,7 +129,7 @@ async function open_preview_side() {
     if (vscode.window.activeTextEditor === undefined) {
         vscode.window.showErrorMessage('Please open a document before you execute the weave command.');
     }
-    else if (vscode.window.activeTextEditor.document.languageId!='juliamarkdown') {
+    else if (vscode.window.activeTextEditor.document.languageId != 'juliamarkdown') {
         vscode.window.showErrorMessage('Only julia Markdown (.jmd) files can be weaved.');
     }
     else {
@@ -141,7 +141,7 @@ async function save() {
     if (vscode.window.activeTextEditor === undefined) {
         vscode.window.showErrorMessage('Please open a document before you execute the weave command.');
     }
-    else if (vscode.window.activeTextEditor.document.languageId!='juliamarkdown') {
+    else if (vscode.window.activeTextEditor.document.languageId != 'juliamarkdown') {
         vscode.window.showErrorMessage('Only julia Markdown (.jmd) files can be weaved.');
     }
     else if (vscode.window.activeTextEditor.document.isDirty || vscode.window.activeTextEditor.document.isUntitled) {
@@ -160,10 +160,10 @@ async function save() {
             'multimarkdown: MultiMarkdown',
             'md2pdf: Julia markdown to latex',
             'asciidoc: AsciiDoc'];
-        let result_format = await vscode.window.showQuickPick(formats, {placeHolder: 'Select output format'});
-        if (result_format!=undefined) {
+        let result_format = await vscode.window.showQuickPick(formats, { placeHolder: 'Select output format' });
+        if (result_format != undefined) {
             let index = result_format.indexOf(':');
-            let selected_format = result_format.substring(0,index);
+            let selected_format = result_format.substring(0, index);
             weave_core(vscode.ViewColumn.One, selected_format);
         }
     }


### PR DESCRIPTION
This should fix the issue that the rearrangement of the typescript files broke the plotting stuff. I actually think it also broke a number of other things :)

This PR ends up being quite large because I did a whole bunch of things:
- split more things out into their own files
- only use classes where we need to, for now it seems easier to just stick with globals in modules, we can still change that later
- I introduced a general pattern how new features can live in their own file

My gut sense is that we can merge this soonish, but then we need to make sure we actually test all the features we have with the new version to make sure we 1) fixed the things that were broken and 2) I didn't introduce new bugs.