### PR TITLE
Use different keyboard shortcut for run block

### DIFF
--- a/package.json
+++ b/package.json
@@ -231,11 +231,11 @@
             {
                 "command": "language-julia.executeJuliaCodeInREPL",
                 "key": "ctrl+Enter",
-                "when": "editorTextFocus && editorLangId == julia && editorHasSelection"
+                "when": "editorTextFocus && editorLangId == julia"
             },
             {
                 "command": "language-julia.executeJuliaBlockInREPL",
-                "key": "ctrl+Enter",
+                "key": "alt+Enter",
                 "when": "editorTextFocus && editorLangId == julia && !editorHasSelection"
             },
             {


### PR DESCRIPTION
Alright, I just miss Ctrl+Enter for "execute current line" too much to not give it a default binding :) Plus, Alt+Enter is free, so we can use that for execute block.

Plus, it means we don't have any breaking change.