### PR TITLE
Fix bug in execute file

### DIFF
--- a/src/repl.ts
+++ b/src/repl.ts
@@ -266,7 +266,10 @@ function executeFile() {
     if (!editor) {
         return;
     }
-    sendMessage('repl/include', editor.document.fileName)
+
+    let text = editor.document.getText();
+
+    executeCode(text)
 }
 
 async function executeJuliaBlockInRepl() {


### PR DESCRIPTION
This should fix #386 and #385.

@ZacLN There are at least two issues with the old version: 1) any error in the user code will kill the task that processes messages. We could put the ``eval`` into a ``try catch`` block, but then we would also need some code that displays an error message etc. Seemed all too complicated at this stage. 2) F5 would execute the saved file, not the stuff in the editor.

I think for now this PR might be the easiest and safest fix?