### PR TITLE
Make julia.runlinter a window scope setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -310,7 +310,8 @@
                 "julia.runlinter": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Option to automatically run the Linter on active files."
+                    "description": "Option to automatically run the Linter on active files.",
+                    "scope": "window"
                 }
             }
         },


### PR DESCRIPTION
This is not great, but should be good enough for the 0.9.0 release, and then we can revisit in a future release.