### PR TITLE
use full exec path

### DIFF
--- a/src/juliaexepath.ts
+++ b/src/juliaexepath.ts
@@ -35,7 +35,7 @@ export async function getJuliaExePath() {
             let foundJulia = false;
             for (let p of pathsToSearch) {
                 try {
-                    var res = await exec(`"${p}" -e "println(VERSION < v\\"0.7-\\" ? JULIA_HOME : Sys.BINDIR)"`);
+                    var res = await exec(`"${p}" --startup-file=no --history-file=no -e "println(VERSION < v\\"0.7-\\" ? JULIA_HOME : Sys.BINDIR)"`);
                     if (p == 'julia' || p == "julia.exe") {
                         // use full path
                         actualJuliaExePath = path.join(res.stdout.trim(), p);

--- a/src/juliaexepath.ts
+++ b/src/juliaexepath.ts
@@ -14,7 +14,7 @@ let actualJuliaExePath: string = null;
 
 export async function getJuliaExePath() {
     if (actualJuliaExePath == null) {
-        if (g_settings.juliaExePath==null) {
+        if (g_settings.juliaExePath == null) {
             let homedir = os.homedir();
             let pathsToSearch = [];
             if (process.platform == "win32") {
@@ -33,15 +33,19 @@ export async function getJuliaExePath() {
                 pathsToSearch = ["julia"];
             }
             let foundJulia = false;
-            for (let path of pathsToSearch) {
+            for (let p of pathsToSearch) {
                 try {
-                    var res = await exec(`"${path}" -v`);
-
-                    actualJuliaExePath = path;
+                    var res = await exec(`"${p}" -e "println(VERSION < v\\"0.7-\\" ? JULIA_HOME : Sys.BINDIR)"`);
+                    if (p == 'julia' || p == "julia.exe") {
+                        // use full path
+                        actualJuliaExePath = path.join(res.stdout.trim(), p);
+                    } else {
+                        actualJuliaExePath = p;
+                    }
                     foundJulia = true;
-                    break;                    
+                    break;
                 }
-                catch(e) {
+                catch (e) {
                 }
             }
             if (!foundJulia) {


### PR DESCRIPTION
using `julia` might trigger error in some case. Use full path works fine.

![screenshot_2018-01-14_14-37-12](https://user-images.githubusercontent.com/9464825/34913609-cd6198fa-f93c-11e7-9962-4c4aec3eef95.png)
