### PR TITLE
Highlight jldoctest blocks as julia in juliamarkdown files

### DIFF
--- a/syntaxes/juliamarkdown.json
+++ b/syntaxes/juliamarkdown.json
@@ -6,7 +6,7 @@
     ],
     "patterns": [
         {
-            "begin": "^(```)(\\{|\\{\\.|)(julia)(;|)\\s*(.*?)(\\}|)\\s*$",
+            "begin": "^(```)(\\{|\\{\\.|)(julia|jldoctest)(;|)\\s*(.*?)(\\}|)\\s*$",
             "beginCaptures": {
                 "1": {
                     "name": "markup.heading.juliamarkdown"


### PR DESCRIPTION
This doesn't introduce special handling for jldoctest but it's an improvement I think.