### PR TITLE
[Discussion] [Live Share] Restrict language services and tasks to local workspaces

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,10 +62,13 @@ export async function activate(context: vscode.ExtensionContext) {
     juliaexepath.activate(context, g_settings);
     repl.activate(context, g_settings);
     weave.activate(context, g_settings);
-    tasks.activate(context, g_settings);
     smallcommands.activate(context, g_settings);
     packagepath.activate(context, g_settings);
     openpackagedirectory.activate(context, g_settings);
+
+    if (vscode.workspace.rootPath) {
+        tasks.activate(context, g_settings);
+    }
 
     // Start language server
     startLanguageServer();
@@ -152,7 +155,10 @@ async function startLanguageServer() {
     };
 
     let clientOptions: LanguageClientOptions = {
-        documentSelector: ['julia', 'juliamarkdown'],
+        documentSelector: [
+            { language: 'julia', scheme: 'file' },
+            { language: 'juliamarkdown', scheme: 'file' },
+        ],
         synchronize: {
             configurationSection: ['julia.runlinter', 'julia.lintIgnoreList'],
             fileEvents: vscode.workspace.createFileSystemWatcher('**/*.jl')


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](https://aka.ms/vsls) adding support for "guests" to receive remote language services and tasks for Julia, this PR simply updates the current `DocumentSelector` to be limited to `file` and `untitled` (unsaved) files. This way, when someone has the Julia extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services and tasks will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).

*Note: As an example, the TypeScript/JavaScript language services that come in-box with VS Code [already have this scheme restriction](https://github.com/Microsoft/vscode/blob/master/extensions/typescript-language-features/src/utils/fileSchemes.ts#L12), and so this PR replicates that behavior.*