### PR TITLE
Fix sendText call on Windows

### DIFF
--- a/src/repl.ts
+++ b/src/repl.ts
@@ -294,7 +294,12 @@ async function executeCode(text) {
     var lines = text.split(/\r?\n/);
     lines = lines.filter(line => line != '');
     text = lines.join('\n');
-    g_terminal.sendText('\u001B[200~' + text + '\n' + '\u001B[201~', false);
+    if (process.platform == "win32") {
+        g_terminal.sendText(text + '\n', false);
+    }
+    else {
+        g_terminal.sendText('\u001B[200~' + text + '\n' + '\u001B[201~', false);
+    }
 }
 
 function executeSelection() {


### PR DESCRIPTION
Fixes #610.

This would replace #622. I think I would prefer not to add an option for this, instead I think we should use this on platforms where it works and not where it doesn't work, but really we should figure that out.