### PR TITLE
Preserve webview panel column

### DIFF
--- a/src/repl.ts
+++ b/src/repl.ts
@@ -49,7 +49,7 @@ function showPlotPane() {
         }, null, g_context.subscriptions);
 
         g_plotPanel.onDidChangeViewState(({ webviewPanel }) => {
-		    vscode.commands.executeCommand('setContext', c_juliaPlotPanelActiveContextKey, webviewPanel.visible);
+		    vscode.commands.executeCommand('setContext', c_juliaPlotPanelActiveContextKey, webviewPanel.active);
 		});
     }
     else {

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -55,7 +55,6 @@ function showPlotPane() {
     else {
         g_plotPanel.title = plotTitle;
         g_plotPanel.webview.html = getPlotPaneContent();
-        g_plotPanel.reveal();
     }
 }
 


### PR DESCRIPTION
I was having an issue with the plot panel. I wanted to write code in one editor column and have the plot panel in another editor column. When I manually moved the plot panel to a second column and redraw the chart, the column disappeared and the plot panel covered my code. 

This PR attempts to fix this so we can leave a plot panel open in another column. Plotting again plots to the same column wherever you put it.

![image](https://user-images.githubusercontent.com/8954730/50469841-3bfd5980-09e9-11e9-860d-a6d8c378985a.png)

Note: I am getting some errors messages that the extension has crashed (it might just be on my side), so let's have a close look and test it out before merging, but wanted to submit to see what you think.