### PR TITLE
Allow permanent opt-out of crash reports

### DIFF
--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -139,7 +139,7 @@ function sendCrashReportQueue() {
 }
 
 async function showCrashReporterUIConsent() {
-    if (crashReporterUIVisible) {
+    if (crashReporterUIVisible || vscode.workspace.getConfiguration('julia').get<boolean>('enableCrashReporter')===false) {
         return;
     }
     else {


### PR DESCRIPTION
I have set both

    "julia.enableCrashReporter": false,
    "julia.enableTelemetry": false,

and was surprised to be asked to send a crash report. From the JuliaCon talk and the [privacy policy](https://github.com/JuliaEditorSupport/julia-vscode/wiki/Privacy-Policy) I assumed that `enableCrashReporter` followed the same logic as `enableTelemetry` (nag unless set to `false`). This PR fixes that. Do note that I could not test this as I don't know how to willfully trigger a crash.