### PR TITLE
Search for `julia.executablePath` in PATH

### DIFF
--- a/package.json
+++ b/package.json
@@ -363,7 +363,8 @@
         "child-process-promise": "^v2.2.1",
         "promised-temp": "^v0.1.0",
         "vscode-jsonrpc": "^4.0.0",
-        "vscode-languageclient": "^5.2.1"
+        "vscode-languageclient": "^5.2.1",
+        "which": "^1.3.1"
     },
     "devDependencies": {
         "@types/mocha": "^5.2.5",

--- a/src/juliaexepath.ts
+++ b/src/juliaexepath.ts
@@ -4,7 +4,10 @@ import * as vslc from 'vscode-languageclient';
 import * as os from 'os';
 import * as path from 'path';
 import * as process from 'process';
+import * as util from 'util';
+import * as which from 'which';
 var exec = require('child-process-promise').exec;
+const whichAsync = util.promisify(which);
 
 let g_context: vscode.ExtensionContext = null;
 let g_settings: settings.ISettings = null;
@@ -58,7 +61,12 @@ export async function getJuliaExePath() {
             }
         }
         else {
-            actualJuliaExePath = g_settings.juliaExePath;
+            if (g_settings.juliaExePath.includes(path.sep)) {
+                actualJuliaExePath = g_settings.juliaExePath;
+            } else {
+                // resolve full path
+                actualJuliaExePath = await whichAsync(g_settings.juliaExePath);
+            }
         }
     }
     return actualJuliaExePath;


### PR DESCRIPTION
This allows specifying the julia binary in `julia.executablePath` without full path by searching the PATH environment variable.

Fixes #687

Note that I did not update `package-lock.json` because `npm install` removes all the caret symbols from version specifications for me, probably because I'm [using a different npm version](https://github.com/npm/npm/issues/20434).