### PR TITLE
Wrap terminalserver in a monitor process. Fixes #653.

### DIFF
--- a/package.json
+++ b/package.json
@@ -326,6 +326,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Display plots within vscode."
+                },
+                "julia.closeTerminalOnSuccess": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When enabled, the Julia terminal will close without prompting for a restart if the Julia process terminated with success."
                 }
             }
         },

--- a/scripts/terminalserver/terminalserver_monitor.jl
+++ b/scripts/terminalserver/terminalserver_monitor.jl
@@ -1,0 +1,14 @@
+#=  Launches the terminal server in a child process. If the child process errors
+out, it prompts the user to dismiss the terminal, thereby preserving any output.
+=#
+try
+    opts = Base.JLOptions()
+    bin = unsafe_string(opts.julia_bin)
+    prj = unsafe_string(opts.project)
+    script = joinpath(@__DIR__, "terminalserver.jl")
+    run(`$bin -q -i --project=$prj $script $ARGS`, wait = true)
+catch e
+    @error e
+    println("\nPress ENTER to dismiss terminal.")
+    readline()
+end

--- a/scripts/terminalserver/terminalserver_monitor.jl
+++ b/scripts/terminalserver/terminalserver_monitor.jl
@@ -8,7 +8,12 @@ try
     script = joinpath(@__DIR__, "terminalserver.jl")
     run(`$bin -q -i --project=$prj $script $ARGS`, wait = true)
 catch e
-    @error e
-    println("\nPress ENTER to dismiss terminal.")
+    msg = "Unexpected error: $e\n\n"
+    try
+        code = match(r"ProcessExited\(([^\(\)]+)\)", msg)[1]
+        msg = "Julia exited with error code $code. "
+    catch
+    end
+    println("$(msg)Press ENTER to dismiss terminal.")
     readline()
 end

--- a/scripts/terminalserver/terminalserver_monitor.jl
+++ b/scripts/terminalserver/terminalserver_monitor.jl
@@ -1,19 +1,43 @@
-#=  Launches the terminal server in a child process. If the child process errors
-out, it prompts the user to dismiss the terminal, thereby preserving any output.
+#=  Launches the terminal server in a child process. On termination, the user is
+prompted to restart.
 =#
-try
-    opts = Base.JLOptions()
-    bin = unsafe_string(opts.julia_bin)
-    prj = unsafe_string(opts.project)
-    script = joinpath(@__DIR__, "terminalserver.jl")
-    run(`$bin -q -i --project=$prj $script $ARGS`, wait = true)
-catch e
-    msg = "Unexpected error: $e\n\n"
-    try
-        code = match(r"ProcessExited\(([^\(\)]+)\)", msg)[1]
-        msg = "Julia exited with error code $code. "
-    catch
+
+const always_terminate_on_success = parse(Bool, popfirst!(ARGS))
+const opts = Base.JLOptions()
+const bin = unsafe_string(opts.julia_bin)
+const prj = unsafe_string(opts.project)
+const script = joinpath(@__DIR__, "terminalserver.jl")
+const cmd = `$bin -q -i --project=$prj $script $ARGS`
+
+let done = false
+    while !done
+
+        # run subprocess
+        try
+            run(cmd, wait = true)
+            if always_terminate_on_success
+                done = true
+            else
+                println("Julia exited normally.")
+            end
+        catch e
+            msg = "Unexpected error: $e"
+            matches = match(r"ProcessExited\(([^\(\)]+)\)", msg)
+            if !isnothing(matches)
+                msg = "Julia exited with error code $(matches[1])."
+            end
+            println(msg)
+        end
+
+        # ask for restart
+        while !done
+            print("Restart? [Y/n] ")
+            ans = lowercase(readline())
+            if length(ans) == 0 || ans[1] == 'y'
+                break
+            elseif ans[1] == 'n'
+                done = true
+            end
+        end
     end
-    println("$(msg)Press ENTER to dismiss terminal.")
-    readline()
 end

--- a/scripts/terminalserver/terminalserver_monitor.jl
+++ b/scripts/terminalserver/terminalserver_monitor.jl
@@ -6,8 +6,9 @@ const always_terminate_on_success = parse(Bool, popfirst!(ARGS))
 const opts = Base.JLOptions()
 const bin = unsafe_string(opts.julia_bin)
 const prj = unsafe_string(opts.project)
+const prj_flag = length(prj) > 0 ? "--project=$prj" : ""
 const script = joinpath(@__DIR__, "terminalserver.jl")
-const cmd = `$bin -q -i --project=$prj $script $ARGS`
+const cmd = `$bin -q -i $prj_flag $script $ARGS`
 
 let done = false
     while !done

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -150,15 +150,15 @@ async function startREPL(preserveFocus: boolean) {
     if (g_terminal == null) {
         startREPLConn()
         startPlotDisplayServer()
-        let args = path.join(g_context.extensionPath, 'scripts', 'terminalserver', 'terminalserver.jl')
+        let args = path.join(g_context.extensionPath, 'scripts', 'terminalserver', 'terminalserver_monitor.jl')
         let exepath = await juliaexepath.getJuliaExePath();
         let pkgenvpath = await jlpkgenv.getEnvPath();
         if (pkgenvpath==null) {
             g_terminal = vscode.window.createTerminal(
                 {
-                    name: "julia", 
-                    shellPath: exepath, 
-                    shellArgs: ['-q', '-i', args, process.pid.toString(), vscode.workspace.getConfiguration("julia").get("useRevise").toString(), vscode.workspace.getConfiguration("julia").get("usePlotPane").toString()],
+                    name: "julia",
+                    shellPath: exepath,
+                    shellArgs: ['-q', args, process.pid.toString(), vscode.workspace.getConfiguration("julia").get("useRevise").toString(), vscode.workspace.getConfiguration("julia").get("usePlotPane").toString()],
                     env: {
                         JULIA_EDITOR: `"${process.execPath}"`
                     }});
@@ -168,7 +168,7 @@ async function startREPL(preserveFocus: boolean) {
                 {
                     name: "julia",
                     shellPath: exepath,
-                    shellArgs: ['-q', '-i', `--project=${pkgenvpath}`, args, process.pid.toString(), vscode.workspace.getConfiguration("julia").get("useRevise").toString(),vscode.workspace.getConfiguration("julia").get("usePlotPane").toString()],
+                    shellArgs: ['-q', `--project=${pkgenvpath}`, args, process.pid.toString(), vscode.workspace.getConfiguration("julia").get("useRevise").toString(), vscode.workspace.getConfiguration("julia").get("usePlotPane").toString()],
                     env: {
                         JULIA_EDITOR: `"${process.execPath}"`
                     }});


### PR DESCRIPTION
The terminal server is wrapped in a monitor process. When the server process exits with an error code, the user is asked whether to restart it. This allows the user to see the output of a failing process before the terminal window closes (addressing #653).

Optionally, and by default, the user is prompted for a restart even on a successful termination of the terminal server process. A setting has been added, however, to allow the user to opt out of the prompt on successful termination, yielding a behavior of the terminal more like that before the addition of the monitor.