### PR TITLE
Better parsing of triple quoted strings

### DIFF
--- a/syntaxes/julia.json
+++ b/syntaxes/julia.json
@@ -493,7 +493,7 @@
           ]
         },
         {
-          "begin": "\"\"\"",
+          "begin": "(?<![[:word:]⁺-ₜ!′∇])\"\"\"",
           "beginCaptures": {
             "0": {
               "name": "punctuation.definition.string.multiline.begin.julia"
@@ -518,13 +518,13 @@
         },
         {
           "name": "string.quoted.double.julia",
-          "begin": "\"",
+          "begin": "(?<![[:word:]⁺-ₜ!′∇\"])\"(?!\"\")",
           "beginCaptures": {
             "0": {
               "name": "punctuation.definition.string.begin.julia"
             }
           },
-          "end": "\"",
+          "end": "(?<!\\\\)\"",
           "endCaptures": {
             "0": {
               "name": "punctuation.definition.string.end.julia"
@@ -565,13 +565,39 @@
           ]
         },
         {
-          "begin": "\\b[[:alpha:]_∇][[:word:]⁺-ₜ!′∇]*\"",
+          "begin": "\\b([[:alpha:]_∇][[:word:]⁺-ₜ!′∇]*)\"\"\"",
           "beginCaptures": {
             "0": {
               "name": "punctuation.definition.string.begin.julia"
+            },
+            "1": {
+              "name": "support.function.macro.julia"
             }
           },
-          "end": "\"([[:alpha:]_∇][[:word:]⁺-ₜ!′∇]*)?",
+          "end": "\"\"\"",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.julia"
+            }
+          },
+          "name": "string.quoted.other.julia",
+          "patterns": [
+            {
+              "include": "#string_escaped_char"
+            }
+          ]
+        },
+        {
+          "begin": "\\b([[:alpha:]_∇][[:word:]⁺-ₜ!′∇]*)\"(?!\")",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.julia"
+            },
+            "1": {
+              "name": "support.function.macro.julia"
+            }
+          },
+          "end": "(?<!\\\\)\"([[:alpha:]_∇][[:word:]⁺-ₜ!′∇]*)?",
           "endCaptures": {
             "0": {
               "name": "punctuation.definition.string.end.julia"


### PR DESCRIPTION
This change ensures triple quoted  standard and non-stadard string literals are parsed properly. Before this change """bla bla bla""" would be parsed as three separate string literals: [""]["bla bla bla"][""] rather than as one string literal ["""bla bla bla"""].

This also changes non-standard string literals, highlighting the prefix with the support.function.macro color.

I ran into this problem while looking to create a small vscode plugin to allow the injection of other languages within Julia (e.g. to properly parse mat"x + 1" as matlab code and py"x + 1" as python code, etc...). Without this change it is quite hard to avoid parsing errors when injecting the grammar (because it is hard to find the triple quoted sections, as they are labeled as three different, ungrouped entities).