### PR TITLE
additional julia command line args

### DIFF
--- a/package.json
+++ b/package.json
@@ -326,6 +326,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Display plots within vscode."
+                },
+                "julia.additionalArgs": {
+                    "type": "array",
+                    "default": [],
+                    "description": "Additional julia arguments."
                 }
             }
         },

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -154,21 +154,25 @@ async function startREPL(preserveFocus: boolean) {
         let exepath = await juliaexepath.getJuliaExePath();
         let pkgenvpath = await jlpkgenv.getEnvPath();
         if (pkgenvpath==null) {
+            let jlarg1 = ['-i','--banner=no'].concat(vscode.workspace.getConfiguration("julia").get("additionalArgs"))
+            let jlarg2 = [args, process.pid.toString(), vscode.workspace.getConfiguration("julia").get("useRevise").toString(), vscode.workspace.getConfiguration("julia").get("usePlotPane").toString()]
             g_terminal = vscode.window.createTerminal(
                 {
                     name: "julia", 
                     shellPath: exepath, 
-                    shellArgs: ['-q', '-i', args, process.pid.toString(), vscode.workspace.getConfiguration("julia").get("useRevise").toString(), vscode.workspace.getConfiguration("julia").get("usePlotPane").toString()],
+                    shellArgs: jlarg1.concat(jlarg2),
                     env: {
                         JULIA_EDITOR: `"${process.execPath}"`
                     }});
         }
         else {
+            let jlarg1 = ['-i', '--banner=no', `--project=${pkgenvpath}`].concat(vscode.workspace.getConfiguration("julia").get("additionalArgs"))
+            let jlarg2 = [args, process.pid.toString(), vscode.workspace.getConfiguration("julia").get("useRevise").toString(),vscode.workspace.getConfiguration("julia").get("usePlotPane").toString()]
             g_terminal = vscode.window.createTerminal(
                 {
                     name: "julia",
                     shellPath: exepath,
-                    shellArgs: ['-q', '-i', `--project=${pkgenvpath}`, args, process.pid.toString(), vscode.workspace.getConfiguration("julia").get("useRevise").toString(),vscode.workspace.getConfiguration("julia").get("usePlotPane").toString()],
+                    shellArgs: jlarg1.concat(jlarg2),
                     env: {
                         JULIA_EDITOR: `"${process.execPath}"`
                     }});


### PR DESCRIPTION
Closes https://github.com/JuliaEditorSupport/julia-vscode/issues/689

Add support for custom command line arguments to julia, where one specify an array in the viscose settings.json, like

```
"julia.additionalArgs": [
    "-O3"
],
```

Also, changes `-q` to `--banner=no` since one may need see repl warnings