### PR TITLE
Return from startREPL once all sockets are started

### DIFF
--- a/scripts/terminalserver/terminalserver.jl
+++ b/scripts/terminalserver/terminalserver.jl
@@ -106,7 +106,7 @@ if issocket(pipename_torepl)
     rm(pipename_torepl)
 end
 
-conn = connect(pipename_fromrepl)
+
 
 function sendMsgToVscode(cmd, payload)
     println(conn, cmd, ":", sizeof(payload))
@@ -115,6 +115,7 @@ end
 
 @async begin
     server = listen(pipename_torepl)
+    conn = connect(pipename_fromrepl)
     while true
         sock = accept(server)
         header = readline(sock)


### PR DESCRIPTION
This fixes how we start up the REPL, so that now all communication channels are operational when `startREPL` returns.