### PR TITLE
Add new execution model

### DIFF
--- a/scripts/terminalserver/repl.jl
+++ b/scripts/terminalserver/repl.jl
@@ -1,3 +1,5 @@
+# Most of the code here is copied from the Juno codebase
+
 using REPL
 using REPL.LineEdit
 

--- a/scripts/terminalserver/repl.jl
+++ b/scripts/terminalserver/repl.jl
@@ -1,0 +1,52 @@
+using REPL
+using REPL.LineEdit
+
+isREPL() = isdefined(Base, :active_repl) &&
+           isdefined(Base.active_repl, :interface) &&
+           isdefined(Base.active_repl.interface, :modes)
+
+juliaprompt = "julia> "
+
+current_prompt = juliaprompt
+
+function hideprompt(f)
+    isREPL() || return f()
+
+    repl = Base.active_repl
+    mistate = repl.mistate
+    mode = mistate.current_mode
+
+    buf = String(take!(copy(LineEdit.buffer(mistate))))
+
+    # clear input buffer
+    truncate(LineEdit.buffer(mistate), 0)
+    LineEdit.refresh_multi_line(mistate)
+
+    print(stdout, "\e[1K\r")
+    r = f()
+
+    flush(stdout)
+    flush(stderr)
+    sleep(0.05)
+
+    # TODO Fix this
+    # pos = @rpc cursorpos()
+    pos = 1,1
+    pos[1] != 0 && println()
+
+    # restore prompt
+    if applicable(LineEdit.write_prompt, stdout, mode)
+      LineEdit.write_prompt(stdout, mode)
+    elseif mode isa LineEdit.PrefixHistoryPrompt || :parent_prompt in fieldnames(typeof(mode))
+      LineEdit.write_prompt(stdout, mode.parent_prompt)
+    else
+      printstyled(stdout, current_prompt, color=:green)
+    end
+
+    truncate(LineEdit.buffer(mistate), 0)
+
+    # restore input buffer
+    LineEdit.edit_insert(LineEdit.buffer(mistate), buf)
+    LineEdit.refresh_multi_line(mistate)
+    r
+  end

--- a/scripts/terminalserver/terminalserver.jl
+++ b/scripts/terminalserver/terminalserver.jl
@@ -145,7 +145,7 @@ end
             source_code = payload_as_string[end_second_line_pos+1:end]
 
             hideprompt() do
-                println(' '^code_column * source_code)
+                # println(' '^code_column * source_code)
 
                 try
 

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -375,14 +375,12 @@ async function executeFile() {
     if (!editor) {
         return;
     }
-    let fname = editor.document.fileName;
-    let isfile = await fs.exists(fname)
-    if (isfile && !(editor.document.isDirty)) {
-	    executeCode('include(raw"' + fname + '")')
-    }
-    else {
-	    executeCode(editor.document.getText())
-    }
+
+    let msg_body = vscode.window.activeTextEditor.document.fileName + '\n' +
+    '0:0' + '\n' +
+    editor.document.getText()
+
+    sendMessage('repl/runcode', msg_body)
 }
 
 async function selectJuliaBlock() {


### PR DESCRIPTION
Fixes #105. Fixes #394. Fixes #443. Fixes #481. Fixes #496. Fixes #506. Fixes #539. Fixes #595.

With this PR we now have two distinct ways to run code: a) send to REPL and b) execute code.

Send to REPL is unchanged to what we had previously, but "execute code" now transfers the code via a pipe to the REPL process and runs it there. Code run that way is much more robust: things like `include` will pick up the correct path, `@__DIR__` and friends work etc.

I think we should keep "send to REPL" the way it is, it also seems useful.

"execute code" currently does not echo the code that is being executed. I'm not sure that is the right choice, but thought we could try that for now. "execute code" also currently doesn't `display` the result of the executed code, which might also not be what we want?

Things that we could still address in follow up PRs: if a text range is selected in the editor, we should probably just execute that exact selection, and skip the block detection logic.

Feedback on these choices would be great! We could also merge this and issue a beta soon, hoping to get feedback from a larger audience?