### PR TITLE
Preserve focus when plot pane is shown

### DIFF
--- a/src/repl.ts
+++ b/src/repl.ts
@@ -39,7 +39,7 @@ function showPlotPane() {
     let plotTitle = g_plots.length > 0 ? `Julia Plots (${g_currentPlotIndex+1}/${g_plots.length})` : "Julia Plots (0/0)";
     if (!g_plotPanel) {
         // Otherwise, create a new panel
-        g_plotPanel = vscode.window.createWebviewPanel('jlplotpane', plotTitle, vscode.ViewColumn.Active, {enableScripts: true});
+        g_plotPanel = vscode.window.createWebviewPanel('jlplotpane', plotTitle, {preserveFocus: true, viewColumn: vscode.ViewColumn.Active}, {enableScripts: true});
         g_plotPanel.webview.html = getPlotPaneContent();
         vscode.commands.executeCommand('setContext', c_juliaPlotPanelActiveContextKey, true);
 


### PR DESCRIPTION
Always annoyed me that I show a plot from the REPL and the REPL loses focus. No longer.