### PR TITLE
Add environmentPath configuration setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -348,6 +348,12 @@
                     "type": "array",
                     "default": [],
                     "description": "Additional julia arguments."
+                },
+                "julia.environmentPath": {
+                    "type": ["string", "null"],
+                    "default": null,
+                    "description": "Path to a julia environment.",
+                    "scope": "window"
                 }
             }
         },

--- a/src/jlpkgenv.ts
+++ b/src/jlpkgenv.ts
@@ -16,10 +16,48 @@ let g_languageClient: vslc.LanguageClient = null;
 let g_current_environment: vscode.StatusBarItem = null;
 
 let g_path_of_current_environment: string = null;
+let g_path_of_default_environment: string = null;
 
 async function switchEnvToPath(envpath: string) {
     g_path_of_current_environment = envpath;
+
+    let section = vscode.workspace.getConfiguration('julia');
+
+    let currentConfigValue = section.get<string>('environmentPath')
+
+    if (g_path_of_current_environment!=await getDefaultEnvPath()) {
+        if (currentConfigValue!=g_path_of_current_environment) {
+            section.update('environmentPath', g_path_of_current_environment, vscode.ConfigurationTarget.Workspace);
+        }
+    }
+    else {
+        if (currentConfigValue!=null) {
+            section.update('environmentPath', undefined, vscode.ConfigurationTarget.Workspace);
+        }
+    }
+
     g_current_environment.text = "Julia env: " + await getEnvName();
+
+    if (vscode.workspace.workspaceFolders!==undefined &&
+        vscode.workspace.workspaceFolders.length==1 &&
+        vscode.workspace.workspaceFolders[0].uri.fsPath != g_path_of_current_environment) {
+
+        let case_adjusted = process.platform == "win32" ?
+            vscode.workspace.workspaceFolders[0].uri.fsPath.charAt(0).toUpperCase() + vscode.workspace.workspaceFolders[0].uri.fsPath.slice(1) :
+            vscode.workspace.workspaceFolders[0].uri.fsPath;
+
+        let jlexepath = await juliaexepath.getJuliaExePath();
+        var res = await exec(`"${jlexepath}" --project=${g_path_of_current_environment} --startup-file=no --history-file=no -e "using Pkg; println(in(ARGS[1], realpath.(filter(i->i!==nothing, getproperty.(values(Pkg.Types.Context().env.manifest), :path)))))" "${case_adjusted}"`);
+
+        if (res.stdout.trim()=="false") {
+            vscode.window.showInformationMessage("You opened a Julia package that is not part of your current environment. Do you want to activate a different environment?", 'Change Julia environment')
+                .then(env_choice => {
+                    if (env_choice == "Change Julia environment") {
+                            changeJuliaEnvironment();
+                    }
+                });
+        }
+    }
 
     g_languageClient.sendNotification("julia/activateenvironment", envpath);
 }
@@ -92,12 +130,40 @@ async function changeJuliaEnvironment() {
     }
 }
 
+async function getDefaultEnvPath() {
+    if (g_path_of_default_environment == null) {
+        if (vscode.workspace.workspaceFolders) {
+            if (vscode.workspace.workspaceFolders.length == 1) {
+                let projectFilePath1 = path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, 'JuliaProject.toml');
+                let manifestFilePath1 = path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, 'JuliaManifest.toml');
+                let projectFilePath2 = path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, 'Project.toml');
+                let manifestFilePath2 = path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, 'Manifest.toml');
+                if (await fs.exists(projectFilePath1) && await fs.exists(manifestFilePath1)) {
+                    return vscode.workspace.workspaceFolders[0].uri.fsPath
+                }
+                else if (await fs.exists(projectFilePath2) && await fs.exists(manifestFilePath2)) {
+                    return vscode.workspace.workspaceFolders[0].uri.fsPath
+                }
+            }
+        }
+
+        let jlexepath = await juliaexepath.getJuliaExePath();
+        var res = await exec(`"${jlexepath}" --startup-file=no --history-file=no -e "using Pkg; println(dirname(Pkg.Types.Context().env.project_file))"`);
+        g_path_of_default_environment = res.stdout.trim();
+    }
+    return g_path_of_default_environment
+}
+
 export async function getEnvPath() {
     if (g_path_of_current_environment == null) {
-        let jlexepath = await juliaexepath.getJuliaExePath();
-        if (vscode.workspace.workspaceFolders) process.chdir(vscode.workspace.workspaceFolders[0].uri.fsPath.toString());
-        var res = await exec(`"${jlexepath}" --startup-file=no --history-file=no --project -e "using Pkg; println(dirname(Pkg.Types.Context().env.project_file))"`);
-        g_path_of_current_environment = res.stdout.trim();
+        let section = vscode.workspace.getConfiguration('julia');
+        let envPathConfig = section.get<string>("environmentPath");
+        if (envPathConfig!==null){
+            g_path_of_current_environment = envPathConfig;
+        }
+        else {
+            g_path_of_current_environment = await getDefaultEnvPath();
+        }
     }
     return g_path_of_current_environment;
 }
@@ -117,7 +183,7 @@ export async function activate(context: vscode.ExtensionContext, settings: setti
     g_current_environment.text = "Julia env: [loading]";
     g_current_environment.command = "language-julia.changeCurrentEnvironment";
     context.subscriptions.push(g_current_environment);
-    switchEnvToPath(await getEnvPath());
+    await switchEnvToPath(await getEnvPath());
 }
 
 export function onDidChangeConfiguration(newSettings: settings.ISettings) {


### PR DESCRIPTION
Fixes #728.

@tribut This takes the next step from your PR we recently changed. The main difference now is that I no longer activate auto activate an environment if there is no `Manifest.toml` present. I played with the implementation that did for a while, and I think one ends up with a sub-par experience. But, one can still pretty easily opt-in to opening a package and automatically getting that `Project.toml` activated as an environment: one just needs to instantiate the env once (thus creating a `Manifest.toml`) and then it will get auto activated.

But the main feature of this PR is that it adds a workspace level setting that stores the env that one selects via the UI, so that this setting gets persisted.