### PR TITLE
Run doc build on temp copy of Project.toml from docs

### DIFF
--- a/scripts/tasks/task_docbuild.jl
+++ b/scripts/tasks/task_docbuild.jl
@@ -1,0 +1,14 @@
+using Pkg
+
+mktempdir() do p
+    cp(joinpath(pwd(), "docs", "Project.toml"), joinpath(p, "Project.toml"))
+
+    Pkg.activate(p)
+
+    Pkg.develop(PackageSpec(path=pwd()))
+    Pkg.instantiate()
+
+    include(Base.ARGS[1])
+end
+
+Sys.isapple() ? run(`open $(Base.ARGS[2])`) : Sys.iswindows() ? run(`cmd /c start $(Base.ARGS[2])`) : Sys.islinux() ? run(`xdg-open $(Base.ARGS[2])`) : nothing

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -81,10 +81,9 @@ async function provideJuliaTasksForFolder(folder: vscode.WorkspaceFolder): Promi
                 new vscode.ProcessExecution(
                     jlexepath,
                     [
-                        '--project=./docs',
+                        `--project=${pkgenvpath}`,
                         '--color=yes',
-                        '-e',
-                        'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include(Base.ARGS[1]); Sys.isapple() ? run(`open $(Base.ARGS[2])`) : Sys.iswindows() ? run(`cmd /c start $(Base.ARGS[2])`) : Sys.islinux() ? run(`xdg-open $(Base.ARGS[2])`) : nothing',
+                        path.join(g_context.extensionPath, 'scripts', 'tasks', 'task_docbuild.jl'),
                         path.join(rootPath, 'docs', 'make.jl'),
                         path.join(rootPath, 'docs', 'build', 'index.html')
                     ],


### PR DESCRIPTION
This should make things somewhat more stable, and it no longer creates a `Manifest.toml` in the docs folder every time one builds the docs.